### PR TITLE
feat(lockfile-lintrc): moved settings to the rc file

### DIFF
--- a/src/linting/lockfile-test.js
+++ b/src/linting/lockfile-test.js
@@ -1,14 +1,31 @@
+import {promises as fs} from 'fs';
 import {assert} from 'chai';
+import sinon from 'sinon';
+import any from '@travi/any';
 import scaffoldLockfileLint from './lockfile';
 
 suite('lockfile linting', () => {
-  test('that the default config is defined', async () => {
-    const {devDependencies, scripts} = await scaffoldLockfileLint();
+  let sandbox;
 
-    assert.deepEqual(devDependencies, ['lockfile-lint']);
-    assert.equal(
-      scripts['lint:lockfile'],
-      'lockfile-lint --path package-lock.json --type npm --validate-https --allowed-hosts npm'
+  setup(() => {
+    sandbox = sinon.createSandbox();
+
+    sandbox.stub(fs, 'writeFile');
+  });
+
+  teardown(() => sandbox.restore());
+
+  test('that the default config is defined', async () => {
+    const projectRoot = any.string();
+
+    const {devDependencies, scripts} = await scaffoldLockfileLint({projectRoot});
+
+    assert.calledWith(
+      fs.writeFile,
+      `${projectRoot}/.lockfile-lintrc.json`,
+      JSON.stringify({path: 'package-lock.json', type: 'npm', 'validate-https': true, 'allowed-hosts': ['npm']})
     );
+    assert.deepEqual(devDependencies, ['lockfile-lint']);
+    assert.equal(scripts['lint:lockfile'], 'lockfile-lint');
   });
 });

--- a/src/linting/lockfile.js
+++ b/src/linting/lockfile.js
@@ -1,8 +1,13 @@
-export default function () {
+import {promises as fs} from 'fs';
+
+export default async function ({projectRoot}) {
+  await fs.writeFile(
+    `${projectRoot}/.lockfile-lintrc.json`,
+    JSON.stringify({path: 'package-lock.json', type: 'npm', 'validate-https': true, 'allowed-hosts': ['npm']})
+  );
+
   return {
     devDependencies: ['lockfile-lint'],
-    scripts: {
-      'lint:lockfile': 'lockfile-lint --path package-lock.json --type npm --validate-https --allowed-hosts npm'
-    }
+    scripts: {'lint:lockfile': 'lockfile-lint'}
   };
 }

--- a/src/linting/scaffolder-test.js
+++ b/src/linting/scaffolder-test.js
@@ -48,7 +48,9 @@ suite('linting scaffolder', () => {
       });
     scaffoldBanSensitiveFiles.default
       .resolves({devDependencies: banSensitiveFilesDevDependencies, scripts: banSensitiveFilesScripts});
-    scaffoldLockfileLint.default.resolves({devDependencies: lockfileDevDependencies, scripts: lockfileScripts});
+    scaffoldLockfileLint.default
+      .withArgs({projectRoot})
+      .resolves({devDependencies: lockfileDevDependencies, scripts: lockfileScripts});
   });
 
   teardown(() => sandbox.restore());

--- a/src/linting/scaffolder.js
+++ b/src/linting/scaffolder.js
@@ -15,7 +15,7 @@ export default async function ({
   eslintConfigs
 }) {
   return deepmerge.all(await Promise.all([
-    scaffoldLockfileLint(),
+    scaffoldLockfileLint({projectRoot}),
     configs.eslint && false !== transpileLint
       ? scaffoldEslint({
         projectRoot,


### PR DESCRIPTION
i kind of prefer config to be in the wasteland of dotfiles in the root of a project rather than last in the `package.json`, but the bigger driver for this is to prepare for choice of package manager as well as defining custom registries for scoped packages