### PR TITLE
fix(babel): instrument istanbul coverage with babel

### DIFF
--- a/src/config/babel-test.js
+++ b/src/config/babel-test.js
@@ -62,7 +62,7 @@ suite('babel config', () => {
     assert.deepEqual(
       await scaffoldBabel({preset: undefined, projectRoot}),
       {
-        devDependencies: ['@babel/register'],
+        devDependencies: [],
         scripts: {},
         vcsIgnore: {files: [], directories: []}
       }

--- a/src/config/babel-test.js
+++ b/src/config/babel-test.js
@@ -22,9 +22,9 @@ suite('babel config', () => {
     const babelPreset = {name: babelPresetName, packageName: babelPresetPackageName};
 
     assert.deepEqual(
-      await scaffoldBabel({preset: babelPreset, projectRoot}),
+      await scaffoldBabel({preset: babelPreset, projectRoot, tests: {unit: true}}),
       {
-        devDependencies: ['@babel/register', babelPresetPackageName],
+        devDependencies: ['@babel/register', babelPresetPackageName, 'babel-plugin-istanbul'],
         scripts: {},
         vcsIgnore: {files: [], directories: []}
       }
@@ -37,10 +37,35 @@ suite('babel config', () => {
     );
   });
 
+  test('that the istanbul plugin dependency is not included if unit testing is not desired', async () => {
+    const babelPresetName = any.string();
+    const babelPresetPackageName = any.word();
+    const babelPreset = {name: babelPresetName, packageName: babelPresetPackageName};
+
+    assert.deepEqual(
+      await scaffoldBabel({preset: babelPreset, projectRoot, tests: {unit: false}}),
+      {
+        devDependencies: ['@babel/register', babelPresetPackageName],
+        scripts: {},
+        vcsIgnore: {files: [], directories: []}
+      }
+    );
+
+    assert.calledWith(
+      fsPromises.writeFile,
+      `${projectRoot}/.babelrc`,
+      JSON.stringify({presets: [babelPresetName], ignore: ['./lib/']})
+    );
+  });
+
   test('that the babelrc is not written if a preset is not defined', async () => {
     assert.deepEqual(
       await scaffoldBabel({preset: undefined, projectRoot}),
-      {devDependencies: ['@babel/register'], scripts: {}, vcsIgnore: {files: [], directories: []}}
+      {
+        devDependencies: ['@babel/register'],
+        scripts: {},
+        vcsIgnore: {files: [], directories: []}
+      }
     );
 
     assert.notCalled(fsPromises.writeFile);

--- a/src/config/babel-test.js
+++ b/src/config/babel-test.js
@@ -33,7 +33,7 @@ suite('babel config', () => {
     assert.calledWith(
       fsPromises.writeFile,
       `${projectRoot}/.babelrc`,
-      JSON.stringify({presets: [babelPresetName], ignore: ['./lib/']})
+      JSON.stringify({presets: [babelPresetName], ignore: ['./lib/'], env: {test: {plugins: ['istanbul']}}})
     );
   });
 

--- a/src/config/babel.js
+++ b/src/config/babel.js
@@ -1,7 +1,7 @@
 import {promises as fsPromises} from 'fs';
 import {warn} from '@travi/cli-messages';
 
-export default async function ({projectRoot, preset, transpileLint}) {
+export default async function ({projectRoot, preset, transpileLint, tests}) {
   if (false === transpileLint) {
     warn('Not configuring transpilation');
 
@@ -11,12 +11,19 @@ export default async function ({projectRoot, preset, transpileLint}) {
   if (preset) {
     await fsPromises.writeFile(
       `${projectRoot}/.babelrc`,
-      JSON.stringify({presets: [preset.name], ignore: ['./lib/'], env: {test: {plugins: ['istanbul']}}})
+      JSON.stringify({
+        presets: [preset.name],
+        ignore: ['./lib/'],
+        ...tests.unit && {env: {test: {plugins: ['istanbul']}}}
+      })
     );
   } else warn('Not configuring transpilation since no babel-config was provided');
 
   return {
-    devDependencies: ['@babel/register', ...preset ? [preset.packageName] : []],
+    devDependencies: [
+      '@babel/register',
+      ...preset ? [preset.packageName, ...tests.unit ? ['babel-plugin-istanbul'] : []] : []
+    ],
     scripts: {},
     vcsIgnore: {files: [], directories: []}
   };

--- a/src/config/babel.js
+++ b/src/config/babel.js
@@ -2,27 +2,26 @@ import {promises as fsPromises} from 'fs';
 import {warn} from '@travi/cli-messages';
 
 export default async function ({projectRoot, preset, transpileLint, tests}) {
-  if (false === transpileLint) {
+  if (false === transpileLint || !preset) {
     warn('Not configuring transpilation');
 
     return {devDependencies: [], scripts: {}, vcsIgnore: {files: [], directories: []}};
   }
 
-  if (preset) {
-    await fsPromises.writeFile(
-      `${projectRoot}/.babelrc`,
-      JSON.stringify({
-        presets: [preset.name],
-        ignore: ['./lib/'],
-        ...tests.unit && {env: {test: {plugins: ['istanbul']}}}
-      })
-    );
-  } else warn('Not configuring transpilation since no babel-config was provided');
+  await fsPromises.writeFile(
+    `${projectRoot}/.babelrc`,
+    JSON.stringify({
+      presets: [preset.name],
+      ignore: ['./lib/'],
+      ...tests.unit && {env: {test: {plugins: ['istanbul']}}}
+    })
+  );
 
   return {
     devDependencies: [
       '@babel/register',
-      ...preset ? [preset.packageName, ...tests.unit ? ['babel-plugin-istanbul'] : []] : []
+      preset.packageName,
+      ...tests.unit ? ['babel-plugin-istanbul'] : []
     ],
     scripts: {},
     vcsIgnore: {files: [], directories: []}

--- a/src/config/babel.js
+++ b/src/config/babel.js
@@ -9,7 +9,10 @@ export default async function ({projectRoot, preset, transpileLint}) {
   }
 
   if (preset) {
-    await fsPromises.writeFile(`${projectRoot}/.babelrc`, JSON.stringify({presets: [preset.name], ignore: ['./lib/']}));
+    await fsPromises.writeFile(
+      `${projectRoot}/.babelrc`,
+      JSON.stringify({presets: [preset.name], ignore: ['./lib/'], env: {test: {plugins: ['istanbul']}}})
+    );
   } else warn('Not configuring transpilation since no babel-config was provided');
 
   return {

--- a/src/scaffolder-test.js
+++ b/src/scaffolder-test.js
@@ -187,7 +187,7 @@ suite('javascript project scaffolder', () => {
         eslintConfigs: [...testingEslintConfigs, ...projectTypeEslintConfigs]
       })
       .resolves(lintingResults);
-    babel.default.withArgs({projectRoot, preset: babelPreset, transpileLint}).resolves(babelResults);
+    babel.default.withArgs({projectRoot, preset: babelPreset, transpileLint, tests}).resolves(babelResults);
     npmConfig.default.resolves(npmResults);
     commitConvention.default.withArgs({projectRoot, configs}).resolves(commitConventionResults);
     nodeVersionScaffolder.default.withArgs({projectRoot, nodeVersionCategory: versionCategory}).resolves(version);
@@ -225,7 +225,7 @@ suite('javascript project scaffolder', () => {
 
       await scaffold(options);
 
-      assert.calledWith(babel.default, {preset: babelPreset, projectRoot, transpileLint});
+      assert.calledWith(babel.default, {preset: babelPreset, projectRoot, transpileLint, tests});
       assert.calledWith(npmConfig.default, {projectRoot, projectType});
     });
   });

--- a/src/scaffolder.js
+++ b/src/scaffolder.js
@@ -92,7 +92,7 @@ export async function scaffold(options) {
         eslintConfigs: [...testingResults.eslintConfigs, ...projectTypeResults.eslintConfigs]
       }),
       scaffoldChoice(ciServices, ci, {projectRoot, vcs, visibility, projectType, nodeVersion, tests}),
-      scaffoldBabel({preset: configs.babelPreset, projectRoot, transpileLint}),
+      scaffoldBabel({preset: configs.babelPreset, projectRoot, transpileLint, tests}),
       scaffoldCommitConvention({projectRoot, configs})
     ])),
     projectTypeResults,


### PR DESCRIPTION
- this fixes the coverage being reported in babelified code, and only
instruments in teh test environment
- this should be safe to add prior to [this pull
request](https://github.com/form8ion/javascript-core/pull/114) since the test
env just wont be set
- fixes form8ion/javascript-core#84