### PR TITLE
fix(vcs-host): accounted for the host name now being normalized to lowercase

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2397,9 +2397,9 @@
       "integrity": "sha512-G6KhSeq6G8qSt2RPqpJMzef7xYTAWe6NWQkjvEcYd9XWZSRQicGHrJLa31YSM6gTnVQrg88zMZkx+h8bN7SqGg=="
     },
     "@travi/project-scaffolder": {
-      "version": "8.11.0",
-      "resolved": "https://registry.npmjs.org/@travi/project-scaffolder/-/project-scaffolder-8.11.0.tgz",
-      "integrity": "sha512-vxjfOhQ/LBWYw2CxiDRKJj60xVC520ITrhDiCSId4JCxX+Q0Um+W7ANoRbmdXXx4wyU34+n4+hazr87JQtQUOw==",
+      "version": "9.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@travi/project-scaffolder/-/project-scaffolder-9.0.0-beta.1.tgz",
+      "integrity": "sha512-xA9xvmiG6lLgJxYed+zgfnyUmLu6AUKJmo7Icgp5TVsXM6o0MConuwVBI0DzIgO/DWjcgdzpQNme+ZhAXZ9hYw==",
       "dev": true,
       "requires": {
         "@form8ion/core": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@travi/eslint-config": "1.0.56",
     "@travi/eslint-config-cucumber": "1.0.5",
     "@travi/eslint-config-mocha": "1.0.8",
-    "@travi/project-scaffolder": "8.11.0",
+    "@travi/project-scaffolder": "9.0.0-beta.1",
     "@travi/travis-scaffolder-javascript": "4.0.0",
     "ban-sensitive-files": "1.9.14",
     "chai": "4.2.0",
@@ -108,6 +108,9 @@
     "snyk": "^1.436.0",
     "touch": "^3.1.0",
     "validate-npm-package-name": "^3.0.0"
+  },
+  "peerDependencies": {
+    "@travi/project-scaffolder": ">=9.0.0-beta.1"
   },
   "snyk": true
 }

--- a/src/config/nyc-test.js
+++ b/src/config/nyc-test.js
@@ -20,7 +20,7 @@ suite('nyc scaffolder', () => {
 
   test('that nyc is scaffolded', async () => {
     assert.deepEqual(
-      await scaffoldNyc({projectRoot, vcs: {owner: vcsOwner, name: vcsName, host: 'GitHub'}, visibility: 'Public'}),
+      await scaffoldNyc({projectRoot, vcs: {owner: vcsOwner, name: vcsName, host: 'github'}, visibility: 'Public'}),
       {
         devDependencies: ['nyc'],
         vcsIgnore: {files: [], directories: ['/coverage/', '/.nyc_output/']},
@@ -63,7 +63,7 @@ suite('nyc scaffolder', () => {
     assert.isUndefined(
       (await scaffoldNyc({
         projectRoot,
-        vcs: {owner: vcsOwner, name: vcsName, host: 'GitHub'},
+        vcs: {owner: vcsOwner, name: vcsName, host: 'github'},
         visibility: 'Private'
       })).badges.status.coverage
     );

--- a/src/config/nyc.js
+++ b/src/config/nyc.js
@@ -14,7 +14,7 @@ export default async function ({projectRoot, vcs, visibility}) {
     vcsIgnore: {files: [], directories: ['/coverage/', '/.nyc_output/']},
     badges: {
       status: {
-        ...vcs && 'GitHub' === vcs.host && 'Public' === visibility && {
+        ...vcs && 'github' === vcs.host && 'Public' === visibility && {
           coverage: {
             img: `https://img.shields.io/codecov/c/github/${vcs.owner}/${vcs.name}.svg`,
             link: `https://codecov.io/github/${vcs.owner}/${vcs.name}`,

--- a/src/package/details-test.js
+++ b/src/package/details-test.js
@@ -105,7 +105,7 @@ suite('package details builder', () => {
     test('that the repository details are defined', () => {
       const packageDetails = buildPackageDetails({
         tests: {},
-        vcs: {host: 'GitHub', name: repoName, owner},
+        vcs: {host: 'github', name: repoName, owner},
         author: {},
         configs: {},
         contributors: []
@@ -121,7 +121,7 @@ suite('package details builder', () => {
         projectType: projectTypes.PACKAGE,
         packageName,
         tests: {},
-        vcs: {host: 'GitHub', name: repoName, owner},
+        vcs: {host: 'github', name: repoName, owner},
         author: {},
         configs: {},
         contributors: []
@@ -135,7 +135,7 @@ suite('package details builder', () => {
 
       const packageDetails = buildPackageDetails({
         tests: {},
-        vcs: {host: 'GitHub', name: repoName, owner},
+        vcs: {host: 'github', name: repoName, owner},
         author: {},
         configs: {},
         contributors: [],

--- a/src/package/details.js
+++ b/src/package/details.js
@@ -25,7 +25,7 @@ function defineScripts(contributors) {
 }
 
 function defineVcsHostDetails(vcs, packageType, packageName, pathWithinParent) {
-  return vcs && 'GitHub' === vcs.host && {
+  return vcs && 'github' === vcs.host && {
     repository: pathWithinParent
       ? {
         type: 'git',

--- a/test/integration/features/step_definitions/vcs-steps.js
+++ b/test/integration/features/step_definitions/vcs-steps.js
@@ -11,7 +11,7 @@ Given(/^the project will not be versioned$/, async function () {
 });
 
 Given(/^the project will be versioned on GitHub$/, async function () {
-  this.vcs = {host: 'GitHub', owner: repoOwner, name: repoName};
+  this.vcs = {host: 'github', owner: repoOwner, name: repoName};
 });
 
 Then('no repository details will be defined', async function () {


### PR DESCRIPTION
BREAKING CHANGE: use with older versions of the project scaffolder will have cases where casing of
the vcs host name will not match conditional checks here. be sure to upgrade the project-scaffolder
to v9