### PR TITLE
Dialects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,20 +29,20 @@
       "dev": true
     },
     "@babel/core": {
-      "version": "7.14.6",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.14.6.tgz",
-      "integrity": "sha512-gJnOEWSqTk96qG5BoIrl5bVtc23DCycmIePPYnamY9RboYdI4nFy5vAQMSl81O5K/W0sLDWfGysnOECC+KUUCA==",
+      "version": "7.14.8",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.14.8.tgz",
+      "integrity": "sha512-/AtaeEhT6ErpDhInbXmjHcUQXH0L0TEgscfcxk1qbOvLuKCa5aZT0SOOtDKFY96/CLROwbLSKyFor6idgNaU4Q==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.14.5",
-        "@babel/generator": "^7.14.5",
+        "@babel/generator": "^7.14.8",
         "@babel/helper-compilation-targets": "^7.14.5",
-        "@babel/helper-module-transforms": "^7.14.5",
-        "@babel/helpers": "^7.14.6",
-        "@babel/parser": "^7.14.6",
+        "@babel/helper-module-transforms": "^7.14.8",
+        "@babel/helpers": "^7.14.8",
+        "@babel/parser": "^7.14.8",
         "@babel/template": "^7.14.5",
-        "@babel/traverse": "^7.14.5",
-        "@babel/types": "^7.14.5",
+        "@babel/traverse": "^7.14.8",
+        "@babel/types": "^7.14.8",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -66,12 +66,12 @@
       }
     },
     "@babel/generator": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.14.5.tgz",
-      "integrity": "sha512-y3rlP+/G25OIX3mYKKIOlQRcqj7YgrvHxOLbVmyLJ9bPmi5ttvUmpydVjcFjZphOktWuA7ovbx91ECloWTfjIA==",
+      "version": "7.14.8",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.14.8.tgz",
+      "integrity": "sha512-cYDUpvIzhBVnMzRoY1fkSEhK/HmwEVwlyULYgn/tMQYd6Obag3ylCjONle3gdErfXBW61SVTlR9QR7uWlgeIkg==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.14.5",
+        "@babel/types": "^7.14.8",
         "jsesc": "^2.5.1",
         "source-map": "^0.5.0"
       },
@@ -228,19 +228,19 @@
       }
     },
     "@babel/helper-module-transforms": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.14.5.tgz",
-      "integrity": "sha512-iXpX4KW8LVODuAieD7MzhNjmM6dzYY5tfRqT+R9HDXWl0jPn/djKmA+G9s/2C2T9zggw5tK1QNqZ70USfedOwA==",
+      "version": "7.14.8",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.14.8.tgz",
+      "integrity": "sha512-RyE+NFOjXn5A9YU1dkpeBaduagTlZ0+fccnIcAGbv1KGUlReBj7utF7oEth8IdIBQPcux0DDgW5MFBH2xu9KcA==",
       "dev": true,
       "requires": {
         "@babel/helper-module-imports": "^7.14.5",
         "@babel/helper-replace-supers": "^7.14.5",
-        "@babel/helper-simple-access": "^7.14.5",
+        "@babel/helper-simple-access": "^7.14.8",
         "@babel/helper-split-export-declaration": "^7.14.5",
-        "@babel/helper-validator-identifier": "^7.14.5",
+        "@babel/helper-validator-identifier": "^7.14.8",
         "@babel/template": "^7.14.5",
-        "@babel/traverse": "^7.14.5",
-        "@babel/types": "^7.14.5"
+        "@babel/traverse": "^7.14.8",
+        "@babel/types": "^7.14.8"
       }
     },
     "@babel/helper-optimise-call-expression": {
@@ -282,12 +282,12 @@
       }
     },
     "@babel/helper-simple-access": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.14.5.tgz",
-      "integrity": "sha512-nfBN9xvmCt6nrMZjfhkl7i0oTV3yxR4/FztsbOASyTvVcoYd0TRHh7eMLdlEcCqobydC0LAF3LtC92Iwxo0wyw==",
+      "version": "7.14.8",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.14.8.tgz",
+      "integrity": "sha512-TrFN4RHh9gnWEU+s7JloIho2T76GPwRHhdzOWLqTrMnlas8T9O7ec+oEDNsRXndOmru9ymH9DFrEOxpzPoSbdg==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.14.5"
+        "@babel/types": "^7.14.8"
       }
     },
     "@babel/helper-skip-transparent-expression-wrappers": {
@@ -309,9 +309,9 @@
       }
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.5.tgz",
-      "integrity": "sha512-5lsetuxCLilmVGyiLEfoHBRX8UCFD+1m2x3Rj97WrW3V7H3u4RWRXA4evMjImCsin2J2YT0QaVDGf+z8ondbAg==",
+      "version": "7.14.8",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.8.tgz",
+      "integrity": "sha512-ZGy6/XQjllhYQrNw/3zfWRwZCTVSiBLZ9DHVZxn9n2gip/7ab8mv2TWlKPIBk26RwedCBoWdjLmn+t9na2Gcow==",
       "dev": true
     },
     "@babel/helper-validator-option": {
@@ -333,14 +333,14 @@
       }
     },
     "@babel/helpers": {
-      "version": "7.14.6",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.14.6.tgz",
-      "integrity": "sha512-yesp1ENQBiLI+iYHSJdoZKUtRpfTlL1grDIX9NRlAVppljLw/4tTyYupIB7uIYmC3stW/imAv8EqaKaS/ibmeA==",
+      "version": "7.14.8",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.14.8.tgz",
+      "integrity": "sha512-ZRDmI56pnV+p1dH6d+UN6GINGz7Krps3+270qqI9UJ4wxYThfAIcI5i7j5vXC4FJ3Wap+S9qcebxeYiqn87DZw==",
       "dev": true,
       "requires": {
         "@babel/template": "^7.14.5",
-        "@babel/traverse": "^7.14.5",
-        "@babel/types": "^7.14.5"
+        "@babel/traverse": "^7.14.8",
+        "@babel/types": "^7.14.8"
       }
     },
     "@babel/highlight": {
@@ -407,9 +407,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.14.7",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.7.tgz",
-      "integrity": "sha512-X67Z5y+VBJuHB/RjwECp8kSl5uYi0BvRbNeWqkaJCVh+LiTPl19WBUfG627psSgp9rSf6ojuXghQM3ha6qHHdA==",
+      "version": "7.14.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.8.tgz",
+      "integrity": "sha512-syoCQFOoo/fzkWDeM0dLEZi5xqurb5vuyzwIMNZRNun+N/9A4cUZeQaE7dTrB8jGaKuJRBtEOajtnmw0I5hvvA==",
       "dev": true
     },
     "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
@@ -1150,22 +1150,6 @@
         "semver": "^6.3.0"
       },
       "dependencies": {
-        "@babel/helper-validator-identifier": {
-          "version": "7.14.8",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.8.tgz",
-          "integrity": "sha512-ZGy6/XQjllhYQrNw/3zfWRwZCTVSiBLZ9DHVZxn9n2gip/7ab8mv2TWlKPIBk26RwedCBoWdjLmn+t9na2Gcow==",
-          "dev": true
-        },
-        "@babel/types": {
-          "version": "7.14.8",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.8.tgz",
-          "integrity": "sha512-iob4soQa7dZw8nodR/KlOQkPh9S4I8RwCxwRIFuiMRYjOzH/KJzdUfDgz6cGi5dDaclXF4P2PAhCdrBJNIg68Q==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.14.8",
-            "to-fast-properties": "^2.0.0"
-          }
-        },
         "semver": {
           "version": "6.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
@@ -1259,29 +1243,29 @@
       }
     },
     "@babel/traverse": {
-      "version": "7.14.7",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.14.7.tgz",
-      "integrity": "sha512-9vDr5NzHu27wgwejuKL7kIOm4bwEtaPQ4Z6cpCmjSuaRqpH/7xc4qcGEscwMqlkwgcXl6MvqoAjZkQ24uSdIZQ==",
+      "version": "7.14.8",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.14.8.tgz",
+      "integrity": "sha512-kexHhzCljJcFNn1KYAQ6A5wxMRzq9ebYpEDV4+WdNyr3i7O44tanbDOR/xjiG2F3sllan+LgwK+7OMk0EmydHg==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.14.5",
-        "@babel/generator": "^7.14.5",
+        "@babel/generator": "^7.14.8",
         "@babel/helper-function-name": "^7.14.5",
         "@babel/helper-hoist-variables": "^7.14.5",
         "@babel/helper-split-export-declaration": "^7.14.5",
-        "@babel/parser": "^7.14.7",
-        "@babel/types": "^7.14.5",
+        "@babel/parser": "^7.14.8",
+        "@babel/types": "^7.14.8",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       }
     },
     "@babel/types": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.5.tgz",
-      "integrity": "sha512-M/NzBpEL95I5Hh4dwhin5JlE7EzO5PHMAuzjxss3tiOBD46KfQvVedN/3jEPZvdRvtsK2222XfdHogNIttFgcg==",
+      "version": "7.14.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.8.tgz",
+      "integrity": "sha512-iob4soQa7dZw8nodR/KlOQkPh9S4I8RwCxwRIFuiMRYjOzH/KJzdUfDgz6cGi5dDaclXF4P2PAhCdrBJNIg68Q==",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.14.5",
+        "@babel/helper-validator-identifier": "^7.14.8",
         "to-fast-properties": "^2.0.0"
       }
     },
@@ -1300,50 +1284,6 @@
         "resolve-from": "5.0.0",
         "resolve-global": "1.0.0",
         "yargs": "^17.0.0"
-      },
-      "dependencies": {
-        "@commitlint/execute-rule": {
-          "version": "13.0.0",
-          "resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-13.0.0.tgz",
-          "integrity": "sha512-lBz2bJhNAgkkU/rFMAw3XBNujbxhxlaFHY3lfKB/MxpAa+pIfmWB3ig9i1VKe0wCvujk02O0WiMleNaRn2KJqw==",
-          "dev": true
-        },
-        "@commitlint/load": {
-          "version": "13.1.0",
-          "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-13.1.0.tgz",
-          "integrity": "sha512-zlZbjJCWnWmBOSwTXis8H7I6pYk6JbDwOCuARA6B9Y/qt2PD+NCo0E/7EuaaFoxjHl+o56QR5QttuMBrf+BJzg==",
-          "dev": true,
-          "requires": {
-            "@commitlint/execute-rule": "^13.0.0",
-            "@commitlint/resolve-extends": "^13.0.0",
-            "@commitlint/types": "^13.1.0",
-            "chalk": "^4.0.0",
-            "cosmiconfig": "^7.0.0",
-            "lodash": "^4.17.19",
-            "resolve-from": "^5.0.0"
-          }
-        },
-        "@commitlint/resolve-extends": {
-          "version": "13.0.0",
-          "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-13.0.0.tgz",
-          "integrity": "sha512-1SyaE+UOsYTkQlTPUOoj4NwxQhGFtYildVS/d0TJuK8a9uAJLw7bhCLH2PEeH5cC2D1do4Eqhx/3bLDrSLH3hg==",
-          "dev": true,
-          "requires": {
-            "import-fresh": "^3.0.0",
-            "lodash": "^4.17.19",
-            "resolve-from": "^5.0.0",
-            "resolve-global": "^1.0.0"
-          }
-        },
-        "@commitlint/types": {
-          "version": "13.1.0",
-          "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-13.1.0.tgz",
-          "integrity": "sha512-zcVjuT+OfKt8h91vhBxt05RMcTGEx6DM7Q9QZeuMbXFk6xgbsSEDMMapbJPA1bCZ81fa/1OQBijSYPrKvtt06g==",
-          "dev": true,
-          "requires": {
-            "chalk": "^4.0.0"
-          }
-        }
       }
     },
     "@commitlint/config-conventional": {
@@ -1363,23 +1303,12 @@
       "requires": {
         "@commitlint/types": "^13.1.0",
         "lodash": "^4.17.19"
-      },
-      "dependencies": {
-        "@commitlint/types": {
-          "version": "13.1.0",
-          "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-13.1.0.tgz",
-          "integrity": "sha512-zcVjuT+OfKt8h91vhBxt05RMcTGEx6DM7Q9QZeuMbXFk6xgbsSEDMMapbJPA1bCZ81fa/1OQBijSYPrKvtt06g==",
-          "dev": true,
-          "requires": {
-            "chalk": "^4.0.0"
-          }
-        }
       }
     },
     "@commitlint/execute-rule": {
-      "version": "12.1.4",
-      "resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-12.1.4.tgz",
-      "integrity": "sha512-h2S1j8SXyNeABb27q2Ok2vD1WfxJiXvOttKuRA9Or7LN6OQoC/KtT3844CIhhWNteNMu/wE0gkTqGxDVAnJiHg==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-13.0.0.tgz",
+      "integrity": "sha512-lBz2bJhNAgkkU/rFMAw3XBNujbxhxlaFHY3lfKB/MxpAa+pIfmWB3ig9i1VKe0wCvujk02O0WiMleNaRn2KJqw==",
       "dev": true
     },
     "@commitlint/format": {
@@ -1390,17 +1319,6 @@
       "requires": {
         "@commitlint/types": "^13.1.0",
         "chalk": "^4.0.0"
-      },
-      "dependencies": {
-        "@commitlint/types": {
-          "version": "13.1.0",
-          "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-13.1.0.tgz",
-          "integrity": "sha512-zcVjuT+OfKt8h91vhBxt05RMcTGEx6DM7Q9QZeuMbXFk6xgbsSEDMMapbJPA1bCZ81fa/1OQBijSYPrKvtt06g==",
-          "dev": true,
-          "requires": {
-            "chalk": "^4.0.0"
-          }
-        }
       }
     },
     "@commitlint/is-ignored": {
@@ -1411,17 +1329,6 @@
       "requires": {
         "@commitlint/types": "^13.1.0",
         "semver": "7.3.5"
-      },
-      "dependencies": {
-        "@commitlint/types": {
-          "version": "13.1.0",
-          "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-13.1.0.tgz",
-          "integrity": "sha512-zcVjuT+OfKt8h91vhBxt05RMcTGEx6DM7Q9QZeuMbXFk6xgbsSEDMMapbJPA1bCZ81fa/1OQBijSYPrKvtt06g==",
-          "dev": true,
-          "requires": {
-            "chalk": "^4.0.0"
-          }
-        }
       }
     },
     "@commitlint/lint": {
@@ -1434,28 +1341,17 @@
         "@commitlint/parse": "^13.1.0",
         "@commitlint/rules": "^13.1.0",
         "@commitlint/types": "^13.1.0"
-      },
-      "dependencies": {
-        "@commitlint/types": {
-          "version": "13.1.0",
-          "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-13.1.0.tgz",
-          "integrity": "sha512-zcVjuT+OfKt8h91vhBxt05RMcTGEx6DM7Q9QZeuMbXFk6xgbsSEDMMapbJPA1bCZ81fa/1OQBijSYPrKvtt06g==",
-          "dev": true,
-          "requires": {
-            "chalk": "^4.0.0"
-          }
-        }
       }
     },
     "@commitlint/load": {
-      "version": "12.1.4",
-      "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-12.1.4.tgz",
-      "integrity": "sha512-Keszi0IOjRzKfxT+qES/n+KZyLrxy79RQz8wWgssCboYjKEp+wC+fLCgbiMCYjI5k31CIzIOq/16J7Ycr0C0EA==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-13.1.0.tgz",
+      "integrity": "sha512-zlZbjJCWnWmBOSwTXis8H7I6pYk6JbDwOCuARA6B9Y/qt2PD+NCo0E/7EuaaFoxjHl+o56QR5QttuMBrf+BJzg==",
       "dev": true,
       "requires": {
-        "@commitlint/execute-rule": "^12.1.4",
-        "@commitlint/resolve-extends": "^12.1.4",
-        "@commitlint/types": "^12.1.4",
+        "@commitlint/execute-rule": "^13.0.0",
+        "@commitlint/resolve-extends": "^13.0.0",
+        "@commitlint/types": "^13.1.0",
         "chalk": "^4.0.0",
         "cosmiconfig": "^7.0.0",
         "lodash": "^4.17.19",
@@ -1477,17 +1373,6 @@
         "@commitlint/types": "^13.1.0",
         "conventional-changelog-angular": "^5.0.11",
         "conventional-commits-parser": "^3.0.0"
-      },
-      "dependencies": {
-        "@commitlint/types": {
-          "version": "13.1.0",
-          "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-13.1.0.tgz",
-          "integrity": "sha512-zcVjuT+OfKt8h91vhBxt05RMcTGEx6DM7Q9QZeuMbXFk6xgbsSEDMMapbJPA1bCZ81fa/1OQBijSYPrKvtt06g==",
-          "dev": true,
-          "requires": {
-            "chalk": "^4.0.0"
-          }
-        }
       }
     },
     "@commitlint/read": {
@@ -1502,15 +1387,6 @@
         "git-raw-commits": "^2.0.0"
       },
       "dependencies": {
-        "@commitlint/types": {
-          "version": "13.1.0",
-          "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-13.1.0.tgz",
-          "integrity": "sha512-zcVjuT+OfKt8h91vhBxt05RMcTGEx6DM7Q9QZeuMbXFk6xgbsSEDMMapbJPA1bCZ81fa/1OQBijSYPrKvtt06g==",
-          "dev": true,
-          "requires": {
-            "chalk": "^4.0.0"
-          }
-        },
         "fs-extra": {
           "version": "10.0.0",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
@@ -1541,9 +1417,9 @@
       }
     },
     "@commitlint/resolve-extends": {
-      "version": "12.1.4",
-      "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-12.1.4.tgz",
-      "integrity": "sha512-R9CoUtsXLd6KSCfsZly04grsH6JVnWFmVtWgWs1KdDpdV+G3TSs37tColMFqglpkx3dsWu8dsPD56+D9YnJfqg==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-13.0.0.tgz",
+      "integrity": "sha512-1SyaE+UOsYTkQlTPUOoj4NwxQhGFtYildVS/d0TJuK8a9uAJLw7bhCLH2PEeH5cC2D1do4Eqhx/3bLDrSLH3hg==",
       "dev": true,
       "requires": {
         "import-fresh": "^3.0.0",
@@ -1563,17 +1439,6 @@
         "@commitlint/to-lines": "^13.0.0",
         "@commitlint/types": "^13.1.0",
         "execa": "^5.0.0"
-      },
-      "dependencies": {
-        "@commitlint/types": {
-          "version": "13.1.0",
-          "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-13.1.0.tgz",
-          "integrity": "sha512-zcVjuT+OfKt8h91vhBxt05RMcTGEx6DM7Q9QZeuMbXFk6xgbsSEDMMapbJPA1bCZ81fa/1OQBijSYPrKvtt06g==",
-          "dev": true,
-          "requires": {
-            "chalk": "^4.0.0"
-          }
-        }
       }
     },
     "@commitlint/to-lines": {
@@ -1637,9 +1502,9 @@
       }
     },
     "@commitlint/types": {
-      "version": "12.1.4",
-      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-12.1.4.tgz",
-      "integrity": "sha512-KRIjdnWNUx6ywz+SJvjmNCbQKcKP6KArhjZhY2l+CWKxak0d77SOjggkMwFTiSgLODOwmuLTbarR2ZfWPiPMlw==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-13.1.0.tgz",
+      "integrity": "sha512-zcVjuT+OfKt8h91vhBxt05RMcTGEx6DM7Q9QZeuMbXFk6xgbsSEDMMapbJPA1bCZ81fa/1OQBijSYPrKvtt06g==",
       "dev": true,
       "requires": {
         "chalk": "^4.0.0"
@@ -1847,129 +1712,6 @@
         "@babel/preset-env": "7.14.8",
         "@babel/preset-react": "7.14.5",
         "babel-plugin-inline-react-svg": "2.0.1"
-      },
-      "dependencies": {
-        "@babel/core": {
-          "version": "7.14.8",
-          "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.14.8.tgz",
-          "integrity": "sha512-/AtaeEhT6ErpDhInbXmjHcUQXH0L0TEgscfcxk1qbOvLuKCa5aZT0SOOtDKFY96/CLROwbLSKyFor6idgNaU4Q==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "^7.14.5",
-            "@babel/generator": "^7.14.8",
-            "@babel/helper-compilation-targets": "^7.14.5",
-            "@babel/helper-module-transforms": "^7.14.8",
-            "@babel/helpers": "^7.14.8",
-            "@babel/parser": "^7.14.8",
-            "@babel/template": "^7.14.5",
-            "@babel/traverse": "^7.14.8",
-            "@babel/types": "^7.14.8",
-            "convert-source-map": "^1.7.0",
-            "debug": "^4.1.0",
-            "gensync": "^1.0.0-beta.2",
-            "json5": "^2.1.2",
-            "semver": "^6.3.0",
-            "source-map": "^0.5.0"
-          }
-        },
-        "@babel/generator": {
-          "version": "7.14.8",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.14.8.tgz",
-          "integrity": "sha512-cYDUpvIzhBVnMzRoY1fkSEhK/HmwEVwlyULYgn/tMQYd6Obag3ylCjONle3gdErfXBW61SVTlR9QR7uWlgeIkg==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.14.8",
-            "jsesc": "^2.5.1",
-            "source-map": "^0.5.0"
-          }
-        },
-        "@babel/helper-module-transforms": {
-          "version": "7.14.8",
-          "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.14.8.tgz",
-          "integrity": "sha512-RyE+NFOjXn5A9YU1dkpeBaduagTlZ0+fccnIcAGbv1KGUlReBj7utF7oEth8IdIBQPcux0DDgW5MFBH2xu9KcA==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-module-imports": "^7.14.5",
-            "@babel/helper-replace-supers": "^7.14.5",
-            "@babel/helper-simple-access": "^7.14.8",
-            "@babel/helper-split-export-declaration": "^7.14.5",
-            "@babel/helper-validator-identifier": "^7.14.8",
-            "@babel/template": "^7.14.5",
-            "@babel/traverse": "^7.14.8",
-            "@babel/types": "^7.14.8"
-          }
-        },
-        "@babel/helper-simple-access": {
-          "version": "7.14.8",
-          "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.14.8.tgz",
-          "integrity": "sha512-TrFN4RHh9gnWEU+s7JloIho2T76GPwRHhdzOWLqTrMnlas8T9O7ec+oEDNsRXndOmru9ymH9DFrEOxpzPoSbdg==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.14.8"
-          }
-        },
-        "@babel/helper-validator-identifier": {
-          "version": "7.14.8",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.8.tgz",
-          "integrity": "sha512-ZGy6/XQjllhYQrNw/3zfWRwZCTVSiBLZ9DHVZxn9n2gip/7ab8mv2TWlKPIBk26RwedCBoWdjLmn+t9na2Gcow==",
-          "dev": true
-        },
-        "@babel/helpers": {
-          "version": "7.14.8",
-          "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.14.8.tgz",
-          "integrity": "sha512-ZRDmI56pnV+p1dH6d+UN6GINGz7Krps3+270qqI9UJ4wxYThfAIcI5i7j5vXC4FJ3Wap+S9qcebxeYiqn87DZw==",
-          "dev": true,
-          "requires": {
-            "@babel/template": "^7.14.5",
-            "@babel/traverse": "^7.14.8",
-            "@babel/types": "^7.14.8"
-          }
-        },
-        "@babel/parser": {
-          "version": "7.14.8",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.8.tgz",
-          "integrity": "sha512-syoCQFOoo/fzkWDeM0dLEZi5xqurb5vuyzwIMNZRNun+N/9A4cUZeQaE7dTrB8jGaKuJRBtEOajtnmw0I5hvvA==",
-          "dev": true
-        },
-        "@babel/traverse": {
-          "version": "7.14.8",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.14.8.tgz",
-          "integrity": "sha512-kexHhzCljJcFNn1KYAQ6A5wxMRzq9ebYpEDV4+WdNyr3i7O44tanbDOR/xjiG2F3sllan+LgwK+7OMk0EmydHg==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "^7.14.5",
-            "@babel/generator": "^7.14.8",
-            "@babel/helper-function-name": "^7.14.5",
-            "@babel/helper-hoist-variables": "^7.14.5",
-            "@babel/helper-split-export-declaration": "^7.14.5",
-            "@babel/parser": "^7.14.8",
-            "@babel/types": "^7.14.8",
-            "debug": "^4.1.0",
-            "globals": "^11.1.0"
-          }
-        },
-        "@babel/types": {
-          "version": "7.14.8",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.8.tgz",
-          "integrity": "sha512-iob4soQa7dZw8nodR/KlOQkPh9S4I8RwCxwRIFuiMRYjOzH/KJzdUfDgz6cGi5dDaclXF4P2PAhCdrBJNIg68Q==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.14.8",
-            "to-fast-properties": "^2.0.0"
-          }
-        },
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-          "dev": true
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
-        }
       }
     },
     "@form8ion/core": {
@@ -2641,9 +2383,9 @@
       }
     },
     "@snyk/docker-registry-v2-client": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/@snyk/docker-registry-v2-client/-/docker-registry-v2-client-2.2.4.tgz",
-      "integrity": "sha512-7JoxHCYAjJQBOEa11Sdb1scjtq/K4HVDlcE10pNFKbmcUn5Gcm/VDJ2RMEbG2oBdmHTTJMJ5RopIiNMSFd669w==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@snyk/docker-registry-v2-client/-/docker-registry-v2-client-2.3.0.tgz",
+      "integrity": "sha512-VYQe/1SuIdQ8C7bA6nzfcEeafsqG1cHaZDFaIt1uYGwI1TI0OWzUIvGRkfgkMkwFBVLRqS1hFczSoxGTT7OMfA==",
       "dev": true,
       "requires": {
         "needle": "^2.5.0",
@@ -2934,12 +2676,12 @@
       }
     },
     "@snyk/snyk-docker-pull": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/@snyk/snyk-docker-pull/-/snyk-docker-pull-3.6.3.tgz",
-      "integrity": "sha512-SXhIAVfBVB/WoMgh3pTJNEKehpHygzqnnqHpg3ucw2rc5z0LqSAJQyYWl3jSAUnl5LgA11UuYD8zj0dsRbed2A==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@snyk/snyk-docker-pull/-/snyk-docker-pull-3.7.0.tgz",
+      "integrity": "sha512-YRNysIPXmVPrP6+Gn8aG8T414r4GiSbxBP2R8CMXgBWFOdAPBoEoFjs7StjBfaVL1p0xl01AudgDnd42HDK9PA==",
       "dev": true,
       "requires": {
-        "@snyk/docker-registry-v2-client": "^2.2.4",
+        "@snyk/docker-registry-v2-client": "^2.3.0",
         "child-process": "^1.0.2",
         "tar-stream": "^2.2.0",
         "tmp": "^0.2.1"
@@ -3116,10 +2858,13 @@
       }
     },
     "@types/debug": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.6.tgz",
-      "integrity": "sha512-7fDOJFA/x8B+sO1901BmHlf5dE1cxBU8mRXj8QOEDnn16hhGJv/IHxJtZhvsabZsIMn0eLIyeOKAeqSNJJYTpA==",
-      "dev": true
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.7.tgz",
+      "integrity": "sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==",
+      "dev": true,
+      "requires": {
+        "@types/ms": "*"
+      }
     },
     "@types/emscripten": {
       "version": "1.39.5",
@@ -3226,10 +2971,16 @@
       "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==",
       "dev": true
     },
+    "@types/ms": {
+      "version": "0.7.31",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
+      "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==",
+      "dev": true
+    },
     "@types/node": {
-      "version": "16.3.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.3.3.tgz",
-      "integrity": "sha512-8h7k1YgQKxKXWckzFCMfsIwn0Y61UK6tlD6y2lOb3hTOIMlK3t9/QwHOhc81TwU+RMf0As5fj7NPjroERCnejQ==",
+      "version": "16.4.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.4.3.tgz",
+      "integrity": "sha512-GKM4FLMkWDc0sfx7tXqPWkM6NBow1kge0fgQh0bOnlqo4iT1kvTvMEKE0c1RtUGnbLlGRXiAA8SumE//90uKAg==",
       "dev": true
     },
     "@types/normalize-package-data": {
@@ -3269,9 +3020,9 @@
       "dev": true
     },
     "@types/semver": {
-      "version": "7.3.7",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.7.tgz",
-      "integrity": "sha512-4g1jrL98mdOIwSOUh6LTlB0Cs9I0dQPwINUhBg7C6pN4HLr8GS8xsksJxilW6S6dQHVi2K/o+lQuQcg7LroCnw==",
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-D/2EJvAlCEtYFEYmmlGwbGXuK886HzyCc3nZX/tkFTQdEU8jZDAgiv08P162yB17y4ZXZoq7yFAnW4GDBb9Now==",
       "dev": true
     },
     "@types/ssri": {
@@ -4360,9 +4111,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001245",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001245.tgz",
-      "integrity": "sha512-768fM9j1PKXpOCKws6eTo3RHmvTUsG9UrpT4WoREFeZgJBTi4/X9g565azS/rVUGtqb8nt7FjLeF5u4kukERnA==",
+      "version": "1.0.30001247",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001247.tgz",
+      "integrity": "sha512-4rS7co+7+AoOSPRPOPUt5/GdaqZc0EsUpWk66ofE3HJTAajUK2Ss2VwoNzVN69ghg8lYYlh0an0Iy4LIHHo9UQ==",
       "dev": true
     },
     "capital-case": {
@@ -5953,9 +5704,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.779",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.779.tgz",
-      "integrity": "sha512-nreave0y/1Qhmo8XtO6C/LpawNyC6U26+q7d814/e+tIqUK073pM+4xW7WUXyqCRa5K4wdxHmNMBAi8ap9nEew==",
+      "version": "1.3.786",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.786.tgz",
+      "integrity": "sha512-AmvbLBj3hepRk8v/DHrFF8gINxOFfDbrn6Ts3PcK46/FBdQb5OMmpamSpZQXSkfi77FfBzYtQtAk+00LCLYMVw==",
       "dev": true
     },
     "elfy": {
@@ -8366,9 +8117,9 @@
       }
     },
     "jszip": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.6.0.tgz",
-      "integrity": "sha512-jgnQoG9LKnWO3mnVNBnfhkh0QknICd1FGSrXcgrl67zioyJ4wgx25o9ZqwNtrROSflGBCGYnJfjrIyRIby1OoQ==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.7.0.tgz",
+      "integrity": "sha512-Y2OlFIzrDOPWUnpU0LORIcDn2xN7rC9yKffFM/7pGhQuhO+SUhfm2trkJ/S5amjFvem0Y+1EALz/MEPkvHXVNw==",
       "dev": true,
       "requires": {
         "lie": "~3.3.0",
@@ -11545,9 +11296,9 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.13.7",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
+      "version": "0.13.9",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
+      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
       "dev": true
     },
     "regenerator-transform": {
@@ -12150,9 +11901,9 @@
       }
     },
     "resolve-alpn": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.1.2.tgz",
-      "integrity": "sha512-8OyfzhAtA32LVUsJSke3auIyINcwdh5l3cvYKdKO0nvsYSKuiLfTM5i78PJswFPT8y6cPW+L1v6/hE95chcpDA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.0.tgz",
+      "integrity": "sha512-e4FNQs+9cINYMO5NMFc6kOUCdohjqFPSgMuwuZAOUWqrfWsen+Yjy5qZFkV5K7VO7tFSLKcUL97olkED7sCBHA==",
       "dev": true
     },
     "resolve-dir": {
@@ -12526,9 +12277,9 @@
       "dev": true
     },
     "snyk": {
-      "version": "1.663.0",
-      "resolved": "https://registry.npmjs.org/snyk/-/snyk-1.663.0.tgz",
-      "integrity": "sha512-DSG4bi+GHvCQ6dZOs1jygvHoZTcM/xEqB/G/WnCtAARjnL7w1BFGNemrdzEUBhLuUXVCguHcnlvOvK5h96agRg==",
+      "version": "1.666.0",
+      "resolved": "https://registry.npmjs.org/snyk/-/snyk-1.666.0.tgz",
+      "integrity": "sha512-NFO7SKdE48sycwI3+7j+bJq1KihDJQ3Ah+8789/oI2gr9eCSGEUsuNxIgF6rM8QNb7Kv7fGgZlBhJRtBBD8Vyw==",
       "dev": true,
       "requires": {
         "@open-policy-agent/opa-wasm": "^1.2.0",
@@ -12831,9 +12582,9 @@
           }
         },
         "tar": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.0.tgz",
-          "integrity": "sha512-DUCttfhsnLCjwoDoFcI+B2iJgYa93vBnDUATYEeRx6sntCTdN01VnqsIuTlALXla/LWooNg0yEGeB+Y8WdFxGA==",
+          "version": "6.1.1",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.1.tgz",
+          "integrity": "sha512-GG0R7yt/CQkvG4fueXDi52Zskqxe2AyRJ+Wm54yqarnBgcX3qRIWh10qLVAAN+mlPFGTfP5UxvD3Fbi11UOTUQ==",
           "dev": true,
           "requires": {
             "chownr": "^2.0.0",
@@ -14096,9 +13847,9 @@
       }
     },
     "tar": {
-      "version": "4.4.13",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz",
-      "integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
+      "version": "4.4.14",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.14.tgz",
+      "integrity": "sha512-ouN3XcSWYOAHmXZ+P4NEFJvqXL50To9OZBSQNNP30vBUFJFZZ0PLX15fnwupv6azfxMUfUDUr2fhYw4zGAEPcg==",
       "dev": true,
       "requires": {
         "chownr": "^1.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9432,9 +9432,9 @@
       "dev": true
     },
     "mocha": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.0.2.tgz",
-      "integrity": "sha512-FpspiWU+UT9Sixx/wKimvnpkeW0mh6ROAKkIaPokj3xZgxeRhcna/k5X57jJghEr8X+Cgu/Vegf8zCX5ugSuTA==",
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.0.3.tgz",
+      "integrity": "sha512-hnYFrSefHxYS2XFGtN01x8un0EwNu2bzKvhpRFhgoybIvMaOkkL60IVPmkb5h6XDmUl4IMSB+rT5cIO4/4bJgg==",
       "dev": true,
       "requires": {
         "@ungap/promise-all-settled": "1.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1932,9 +1932,9 @@
       }
     },
     "@form8ion/javascript-core": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@form8ion/javascript-core/-/javascript-core-2.10.1.tgz",
-      "integrity": "sha512-fDW+CvI8G1p5lQsJOE96UDZCj+0cznM2yi3at6sauS4EDCJzlozb/HhgGjmoO+kCzkjVd7YMb8tma8xctjq1fg==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@form8ion/javascript-core/-/javascript-core-2.12.0.tgz",
+      "integrity": "sha512-pjVHvHIfl8Hc8V79kWtab8cmgA7Axz6FjuurN2ZaBiIV/59Y+xSPaI0a4Gq20o/dNx1+uR1L3OWm/Jd79tBoVw==",
       "requires": {
         "@form8ion/mocha-scaffolder": "^1.0.0",
         "@form8ion/overridable-prompts": "^1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2410,9 +2410,9 @@
       "dev": true
     },
     "@rollup/plugin-node-resolve": {
-      "version": "13.0.2",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-13.0.2.tgz",
-      "integrity": "sha512-hv+eAMcA2hQ7qvPVcXbtIyc0dtue4jMyA2sCW4IMkrmh+SeDDEHg1MXTv65VPpKdtjvWzN3+4mHAEl4rT+zgzQ==",
+      "version": "13.0.3",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-13.0.3.tgz",
+      "integrity": "sha512-Wbq294ydDlsliRlVTZ2QZcdtIiY8t6EeuUKzXw5j5BLQ0i2hcvfGOwol1FDm77lp89MmyNJT6aQWsT0jAAfaQw==",
       "dev": true,
       "requires": {
         "@rollup/pluginutils": "^3.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12283,9 +12283,9 @@
       }
     },
     "rollup": {
-      "version": "2.53.3",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.53.3.tgz",
-      "integrity": "sha512-79QIGP5DXz5ZHYnCPi3tLz+elOQi6gudp9YINdaJdjG0Yddubo6JRFUM//qCZ0Bap/GJrsUoEBVdSOc4AkMlRA==",
+      "version": "2.54.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.54.0.tgz",
+      "integrity": "sha512-RHzvstAVwm9A751NxWIbGPFXs3zL4qe/eYg+N7WwGtIXVLy1cK64MiU37+hXeFm1jqipK6DGgMi6Z2hhPuCC3A==",
       "dev": true,
       "requires": {
         "fsevents": "~2.3.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -12181,9 +12181,9 @@
       }
     },
     "rollup": {
-      "version": "2.53.2",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.53.2.tgz",
-      "integrity": "sha512-1CtEYuS5CRCzFZ7SNW5528SlDlk4VDXIRGwbm/2POQxA/G4+7/crIqJwkmnj8Q/74hGx4oVlNvh4E1CJQ5hZ6w==",
+      "version": "2.53.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.53.3.tgz",
+      "integrity": "sha512-79QIGP5DXz5ZHYnCPi3tLz+elOQi6gudp9YINdaJdjG0Yddubo6JRFUM//qCZ0Bap/GJrsUoEBVdSOc4AkMlRA==",
       "dev": true,
       "requires": {
         "fsevents": "~2.3.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1286,56 +1286,94 @@
       }
     },
     "@commitlint/cli": {
-      "version": "12.1.4",
-      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-12.1.4.tgz",
-      "integrity": "sha512-ZR1WjXLvqEffYyBPT0XdnSxtt3Ty1TMoujEtseW5o3vPnkA1UNashAMjQVg/oELqfaiAMnDw8SERPMN0e/0kLg==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-13.1.0.tgz",
+      "integrity": "sha512-xN/uNYWtGTva5OMSd+xA6e6/c2jk8av7MUbdd6w2cw89u6z3fAWoyiH87X0ewdSMNYmW/6B3L/2dIVGHRDID5w==",
       "dev": true,
       "requires": {
-        "@commitlint/format": "^12.1.4",
-        "@commitlint/lint": "^12.1.4",
-        "@commitlint/load": "^12.1.4",
-        "@commitlint/read": "^12.1.4",
-        "@commitlint/types": "^12.1.4",
+        "@commitlint/format": "^13.1.0",
+        "@commitlint/lint": "^13.1.0",
+        "@commitlint/load": "^13.1.0",
+        "@commitlint/read": "^13.1.0",
+        "@commitlint/types": "^13.1.0",
         "lodash": "^4.17.19",
         "resolve-from": "5.0.0",
         "resolve-global": "1.0.0",
-        "yargs": "^16.2.0"
+        "yargs": "^17.0.0"
       },
       "dependencies": {
-        "yargs": {
-          "version": "16.2.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-          "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+        "@commitlint/execute-rule": {
+          "version": "13.0.0",
+          "resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-13.0.0.tgz",
+          "integrity": "sha512-lBz2bJhNAgkkU/rFMAw3XBNujbxhxlaFHY3lfKB/MxpAa+pIfmWB3ig9i1VKe0wCvujk02O0WiMleNaRn2KJqw==",
+          "dev": true
+        },
+        "@commitlint/load": {
+          "version": "13.1.0",
+          "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-13.1.0.tgz",
+          "integrity": "sha512-zlZbjJCWnWmBOSwTXis8H7I6pYk6JbDwOCuARA6B9Y/qt2PD+NCo0E/7EuaaFoxjHl+o56QR5QttuMBrf+BJzg==",
           "dev": true,
           "requires": {
-            "cliui": "^7.0.2",
-            "escalade": "^3.1.1",
-            "get-caller-file": "^2.0.5",
-            "require-directory": "^2.1.1",
-            "string-width": "^4.2.0",
-            "y18n": "^5.0.5",
-            "yargs-parser": "^20.2.2"
+            "@commitlint/execute-rule": "^13.0.0",
+            "@commitlint/resolve-extends": "^13.0.0",
+            "@commitlint/types": "^13.1.0",
+            "chalk": "^4.0.0",
+            "cosmiconfig": "^7.0.0",
+            "lodash": "^4.17.19",
+            "resolve-from": "^5.0.0"
+          }
+        },
+        "@commitlint/resolve-extends": {
+          "version": "13.0.0",
+          "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-13.0.0.tgz",
+          "integrity": "sha512-1SyaE+UOsYTkQlTPUOoj4NwxQhGFtYildVS/d0TJuK8a9uAJLw7bhCLH2PEeH5cC2D1do4Eqhx/3bLDrSLH3hg==",
+          "dev": true,
+          "requires": {
+            "import-fresh": "^3.0.0",
+            "lodash": "^4.17.19",
+            "resolve-from": "^5.0.0",
+            "resolve-global": "^1.0.0"
+          }
+        },
+        "@commitlint/types": {
+          "version": "13.1.0",
+          "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-13.1.0.tgz",
+          "integrity": "sha512-zcVjuT+OfKt8h91vhBxt05RMcTGEx6DM7Q9QZeuMbXFk6xgbsSEDMMapbJPA1bCZ81fa/1OQBijSYPrKvtt06g==",
+          "dev": true,
+          "requires": {
+            "chalk": "^4.0.0"
           }
         }
       }
     },
     "@commitlint/config-conventional": {
-      "version": "12.1.4",
-      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-12.1.4.tgz",
-      "integrity": "sha512-ZIdzmdy4o4WyqywMEpprRCrehjCSQrHkaRTVZV411GyLigFQHlEBSJITAihLAWe88Qy/8SyoIe5uKvAsV5vRqQ==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-13.1.0.tgz",
+      "integrity": "sha512-zukJXqdr6jtMiVRy3tTHmwgKcUMGfqKDEskRigc5W3k2aYF4gBAtCEjMAJGZgSQE4DMcHeok0pEV2ANmTpb0cw==",
       "dev": true,
       "requires": {
         "conventional-changelog-conventionalcommits": "^4.3.1"
       }
     },
     "@commitlint/ensure": {
-      "version": "12.1.4",
-      "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-12.1.4.tgz",
-      "integrity": "sha512-MxHIBuAG9M4xl33qUfIeMSasbv3ktK0W+iygldBxZOL4QSYC2Gn66pZAQMnV9o3V+sVFHoAK2XUKqBAYrgbEqw==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-13.1.0.tgz",
+      "integrity": "sha512-NRGyjOdZQnlYwm9it//BZJ2Vm+4x7G9rEnHpLCvNKYY0c6RA8Qf7hamLAB8dWO12RLuFt06JaOpHZoTt/gHutA==",
       "dev": true,
       "requires": {
-        "@commitlint/types": "^12.1.4",
+        "@commitlint/types": "^13.1.0",
         "lodash": "^4.17.19"
+      },
+      "dependencies": {
+        "@commitlint/types": {
+          "version": "13.1.0",
+          "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-13.1.0.tgz",
+          "integrity": "sha512-zcVjuT+OfKt8h91vhBxt05RMcTGEx6DM7Q9QZeuMbXFk6xgbsSEDMMapbJPA1bCZ81fa/1OQBijSYPrKvtt06g==",
+          "dev": true,
+          "requires": {
+            "chalk": "^4.0.0"
+          }
+        }
       }
     },
     "@commitlint/execute-rule": {
@@ -1345,35 +1383,68 @@
       "dev": true
     },
     "@commitlint/format": {
-      "version": "12.1.4",
-      "resolved": "https://registry.npmjs.org/@commitlint/format/-/format-12.1.4.tgz",
-      "integrity": "sha512-h28ucMaoRjVvvgS6Bdf85fa/+ZZ/iu1aeWGCpURnQV7/rrVjkhNSjZwGlCOUd5kDV1EnZ5XdI7L18SUpRjs26g==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/format/-/format-13.1.0.tgz",
+      "integrity": "sha512-n46rYvzf+6Sm99TJjTLjJBkjm6JVcklt31lDO5Q+pCIV0NnJ4qIUcwa6wIL9a9Vqb1XzlMgtp27E0zyYArkvSg==",
       "dev": true,
       "requires": {
-        "@commitlint/types": "^12.1.4",
+        "@commitlint/types": "^13.1.0",
         "chalk": "^4.0.0"
+      },
+      "dependencies": {
+        "@commitlint/types": {
+          "version": "13.1.0",
+          "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-13.1.0.tgz",
+          "integrity": "sha512-zcVjuT+OfKt8h91vhBxt05RMcTGEx6DM7Q9QZeuMbXFk6xgbsSEDMMapbJPA1bCZ81fa/1OQBijSYPrKvtt06g==",
+          "dev": true,
+          "requires": {
+            "chalk": "^4.0.0"
+          }
+        }
       }
     },
     "@commitlint/is-ignored": {
-      "version": "12.1.4",
-      "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-12.1.4.tgz",
-      "integrity": "sha512-uTu2jQU2SKvtIRVLOzMQo3KxDtO+iJ1p0olmncwrqy4AfPLgwoyCP2CiULq5M7xpR3+dE3hBlZXbZTQbD7ycIw==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-13.1.0.tgz",
+      "integrity": "sha512-P6zenLE5Tn3FTNjRzmL9+/KooTXEI0khA2TmUbuei9KiycemeO4q7Xk7w7aXwFPNAbN0O9oI7z3z7cFpzKJWmQ==",
       "dev": true,
       "requires": {
-        "@commitlint/types": "^12.1.4",
+        "@commitlint/types": "^13.1.0",
         "semver": "7.3.5"
+      },
+      "dependencies": {
+        "@commitlint/types": {
+          "version": "13.1.0",
+          "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-13.1.0.tgz",
+          "integrity": "sha512-zcVjuT+OfKt8h91vhBxt05RMcTGEx6DM7Q9QZeuMbXFk6xgbsSEDMMapbJPA1bCZ81fa/1OQBijSYPrKvtt06g==",
+          "dev": true,
+          "requires": {
+            "chalk": "^4.0.0"
+          }
+        }
       }
     },
     "@commitlint/lint": {
-      "version": "12.1.4",
-      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-12.1.4.tgz",
-      "integrity": "sha512-1kZ8YDp4to47oIPFELUFGLiLumtPNKJigPFDuHt2+f3Q3IKdQ0uk53n3CPl4uoyso/Og/EZvb1mXjFR/Yce4cA==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-13.1.0.tgz",
+      "integrity": "sha512-qH9AYSQDDTaSWSdtOvB3G1RdPpcYSgddAdFYqpFewlKQ1GJj/L+sM7vwqCG7/ip6AiM04Sry1sgmFzaEoFREUA==",
       "dev": true,
       "requires": {
-        "@commitlint/is-ignored": "^12.1.4",
-        "@commitlint/parse": "^12.1.4",
-        "@commitlint/rules": "^12.1.4",
-        "@commitlint/types": "^12.1.4"
+        "@commitlint/is-ignored": "^13.1.0",
+        "@commitlint/parse": "^13.1.0",
+        "@commitlint/rules": "^13.1.0",
+        "@commitlint/types": "^13.1.0"
+      },
+      "dependencies": {
+        "@commitlint/types": {
+          "version": "13.1.0",
+          "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-13.1.0.tgz",
+          "integrity": "sha512-zcVjuT+OfKt8h91vhBxt05RMcTGEx6DM7Q9QZeuMbXFk6xgbsSEDMMapbJPA1bCZ81fa/1OQBijSYPrKvtt06g==",
+          "dev": true,
+          "requires": {
+            "chalk": "^4.0.0"
+          }
+        }
       }
     },
     "@commitlint/load": {
@@ -1392,41 +1463,60 @@
       }
     },
     "@commitlint/message": {
-      "version": "12.1.4",
-      "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-12.1.4.tgz",
-      "integrity": "sha512-6QhalEKsKQ/Y16/cTk5NH4iByz26fqws2ub+AinHPtM7Io0jy4e3rym9iE+TkEqiqWZlUigZnTwbPvRJeSUBaA==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-13.0.0.tgz",
+      "integrity": "sha512-W/pxhesVEk8747BEWJ+VGQ9ILHmCV27/pEwJ0hGny1wqVquUR8SxvScRCbUjHCB1YtWX4dEnOPXOS9CLH/CX7A==",
       "dev": true
     },
     "@commitlint/parse": {
-      "version": "12.1.4",
-      "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-12.1.4.tgz",
-      "integrity": "sha512-yqKSAsK2V4X/HaLb/yYdrzs6oD/G48Ilt0EJ2Mp6RJeWYxG14w/Out6JrneWnr/cpzemyN5hExOg6+TB19H/Lw==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-13.1.0.tgz",
+      "integrity": "sha512-xFybZcqBiKVjt6vTStvQkySWEUYPI0AcO4QQELyy29o8EzYZqWkhUfrb7K61fWiHsplWL1iL6F3qCLoxSgTcrg==",
       "dev": true,
       "requires": {
-        "@commitlint/types": "^12.1.4",
+        "@commitlint/types": "^13.1.0",
         "conventional-changelog-angular": "^5.0.11",
         "conventional-commits-parser": "^3.0.0"
+      },
+      "dependencies": {
+        "@commitlint/types": {
+          "version": "13.1.0",
+          "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-13.1.0.tgz",
+          "integrity": "sha512-zcVjuT+OfKt8h91vhBxt05RMcTGEx6DM7Q9QZeuMbXFk6xgbsSEDMMapbJPA1bCZ81fa/1OQBijSYPrKvtt06g==",
+          "dev": true,
+          "requires": {
+            "chalk": "^4.0.0"
+          }
+        }
       }
     },
     "@commitlint/read": {
-      "version": "12.1.4",
-      "resolved": "https://registry.npmjs.org/@commitlint/read/-/read-12.1.4.tgz",
-      "integrity": "sha512-TnPQSJgD8Aod5Xeo9W4SaYKRZmIahukjcCWJ2s5zb3ZYSmj6C85YD9cR5vlRyrZjj78ItLUV/X4FMWWVIS38Jg==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/read/-/read-13.1.0.tgz",
+      "integrity": "sha512-NrVe23GMKyL6i1yDJD8IpqCBzhzoS3wtLfDj8QBzc01Ov1cYBmDojzvBklypGb+MLJM1NbzmRM4PR5pNX0U/NQ==",
       "dev": true,
       "requires": {
-        "@commitlint/top-level": "^12.1.4",
-        "@commitlint/types": "^12.1.4",
-        "fs-extra": "^9.0.0",
+        "@commitlint/top-level": "^13.0.0",
+        "@commitlint/types": "^13.1.0",
+        "fs-extra": "^10.0.0",
         "git-raw-commits": "^2.0.0"
       },
       "dependencies": {
-        "fs-extra": {
-          "version": "9.1.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-          "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+        "@commitlint/types": {
+          "version": "13.1.0",
+          "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-13.1.0.tgz",
+          "integrity": "sha512-zcVjuT+OfKt8h91vhBxt05RMcTGEx6DM7Q9QZeuMbXFk6xgbsSEDMMapbJPA1bCZ81fa/1OQBijSYPrKvtt06g==",
           "dev": true,
           "requires": {
-            "at-least-node": "^1.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
+        "fs-extra": {
+          "version": "10.0.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
+          "integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
+          "dev": true,
+          "requires": {
             "graceful-fs": "^4.2.0",
             "jsonfile": "^6.0.1",
             "universalify": "^2.0.0"
@@ -1463,27 +1553,39 @@
       }
     },
     "@commitlint/rules": {
-      "version": "12.1.4",
-      "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-12.1.4.tgz",
-      "integrity": "sha512-W8m6ZSjg7RuIsIfzQiFHa48X5mcPXeKT9yjBxVmjHvYfS2FDBf1VxCQ7vO0JTVIdV4ohjZ0eKg/wxxUuZHJAZg==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-13.1.0.tgz",
+      "integrity": "sha512-b6F+vBqEXsHVghrhomG0Y6YJimHZqkzZ0n5QEpk03dpBXH2OnsezpTw5e+GvbyYCc7PutGbYVQkytuv+7xCxYA==",
       "dev": true,
       "requires": {
-        "@commitlint/ensure": "^12.1.4",
-        "@commitlint/message": "^12.1.4",
-        "@commitlint/to-lines": "^12.1.4",
-        "@commitlint/types": "^12.1.4"
+        "@commitlint/ensure": "^13.1.0",
+        "@commitlint/message": "^13.0.0",
+        "@commitlint/to-lines": "^13.0.0",
+        "@commitlint/types": "^13.1.0",
+        "execa": "^5.0.0"
+      },
+      "dependencies": {
+        "@commitlint/types": {
+          "version": "13.1.0",
+          "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-13.1.0.tgz",
+          "integrity": "sha512-zcVjuT+OfKt8h91vhBxt05RMcTGEx6DM7Q9QZeuMbXFk6xgbsSEDMMapbJPA1bCZ81fa/1OQBijSYPrKvtt06g==",
+          "dev": true,
+          "requires": {
+            "chalk": "^4.0.0"
+          }
+        }
       }
     },
     "@commitlint/to-lines": {
-      "version": "12.1.4",
-      "resolved": "https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-12.1.4.tgz",
-      "integrity": "sha512-TParumvbi8bdx3EdLXz2MaX+e15ZgoCqNUgqHsRLwyqLUTRbqCVkzrfadG1UcMQk8/d5aMbb327ZKG3Q4BRorw==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-13.0.0.tgz",
+      "integrity": "sha512-mzxWwCio1M4/kG9/69TTYqrraQ66LmtJCYTzAZdZ2eJX3I5w52pSjyP/DJzAUVmmJCYf2Kw3s+RtNVShtnZ+Rw==",
       "dev": true
     },
     "@commitlint/top-level": {
-      "version": "12.1.4",
-      "resolved": "https://registry.npmjs.org/@commitlint/top-level/-/top-level-12.1.4.tgz",
-      "integrity": "sha512-d4lTJrOT/dXlpY+NIt4CUl77ciEzYeNVc0VFgUQ6VA+b1rqYD2/VWFjBlWVOrklxtSDeKyuEhs36RGrppEFAvg==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/top-level/-/top-level-13.0.0.tgz",
+      "integrity": "sha512-baBy3MZBF28sR93yFezd4a5TdHsbXaakeladfHK9dOcGdXo9oQe3GS5hP3BmlN680D6AiQSN7QPgEJgrNUWUCg==",
       "dev": true,
       "requires": {
         "find-up": "^5.0.0"
@@ -5059,13 +5161,13 @@
       }
     },
     "commitlint-config-travi": {
-      "version": "1.3.16",
-      "resolved": "https://registry.npmjs.org/commitlint-config-travi/-/commitlint-config-travi-1.3.16.tgz",
-      "integrity": "sha512-ryPWJzdmr9OkTIIJBs5Pjzod3OLYzQfjbrssoCI8nyUpLBT5thkKnTGFRkQV6Y9mEgerBzoL6EmlZJ6yM4DcNg==",
+      "version": "1.3.17",
+      "resolved": "https://registry.npmjs.org/commitlint-config-travi/-/commitlint-config-travi-1.3.17.tgz",
+      "integrity": "sha512-WfZm3Qk7CGp7wClWdJH2fs1FcOhAMoiWjUBo+Vs8obWlbaieqzmr1wvR7+GIAFppMojv5Pw+9Xz57R0oJUQuKQ==",
       "dev": true,
       "requires": {
-        "@commitlint/cli": "12.1.4",
-        "@commitlint/config-conventional": "12.1.4"
+        "@commitlint/cli": "13.1.0",
+        "@commitlint/config-conventional": "13.1.0"
       }
     },
     "commondir": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2410,9 +2410,9 @@
       "dev": true
     },
     "@rollup/plugin-node-resolve": {
-      "version": "13.0.3",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-13.0.3.tgz",
-      "integrity": "sha512-Wbq294ydDlsliRlVTZ2QZcdtIiY8t6EeuUKzXw5j5BLQ0i2hcvfGOwol1FDm77lp89MmyNJT6aQWsT0jAAfaQw==",
+      "version": "13.0.4",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-13.0.4.tgz",
+      "integrity": "sha512-eYq4TFy40O8hjeDs+sIxEH/jc9lyuI2k9DM557WN6rO5OpnC2qXMBNj4IKH1oHrnAazL49C5p0tgP0/VpqJ+/w==",
       "dev": true,
       "requires": {
         "@rollup/pluginutils": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "remark-preset-lint-travi": "1.3.13",
     "remark-toc": "7.2.0",
     "remark-usage": "9.0.0",
-    "rollup": "2.53.2",
+    "rollup": "2.53.3",
     "rollup-plugin-auto-external": "2.0.0",
     "sinon": "11.1.1",
     "testdouble": "3.16.1",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "@form8ion/core": "1.4.2",
     "@form8ion/eslint": "2.0.1",
     "@form8ion/husky": "1.3.0",
-    "@form8ion/javascript-core": "^2.10.1",
+    "@form8ion/javascript-core": "^2.12.0",
     "@form8ion/lift-javascript": "3.1.3",
     "@form8ion/overridable-prompts": "^1.1.0",
     "@hapi/hoek": "^9.2.0",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "check-engine": "1.10.0",
     "clear-module": "4.1.1",
     "codecov": "3.8.3",
-    "commitlint-config-travi": "1.3.16",
+    "commitlint-config-travi": "1.3.17",
     "cz-conventional-changelog": "3.3.0",
     "gherkin-lint": "4.2.2",
     "husky": "7.0.1",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   "devDependencies": {
     "@babel/register": "7.14.5",
     "@cucumber/cucumber": "7.3.1",
-    "@rollup/plugin-node-resolve": "13.0.2",
+    "@rollup/plugin-node-resolve": "13.0.3",
     "@travi/any": "2.0.17",
     "@travi/babel-preset": "3.0.61",
     "@travi/eslint-config": "1.0.77",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "import-fresh": "3.3.0",
     "js-yaml": "4.1.0",
     "lockfile-lint": "4.6.2",
-    "mocha": "9.0.2",
+    "mocha": "9.0.3",
     "mock-fs": "5.0.0",
     "npm-run-all": "4.1.5",
     "nyc": "15.1.0",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "remark-preset-lint-travi": "1.3.13",
     "remark-toc": "7.2.0",
     "remark-usage": "9.0.0",
-    "rollup": "2.53.3",
+    "rollup": "2.54.0",
     "rollup-plugin-auto-external": "2.0.0",
     "sinon": "11.1.1",
     "testdouble": "3.16.1",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   "devDependencies": {
     "@babel/register": "7.14.5",
     "@cucumber/cucumber": "7.3.1",
-    "@rollup/plugin-node-resolve": "13.0.3",
+    "@rollup/plugin-node-resolve": "13.0.4",
     "@travi/any": "2.0.17",
     "@travi/babel-preset": "3.0.61",
     "@travi/eslint-config": "1.0.77",

--- a/src/dialects/babel-test.js
+++ b/src/dialects/babel-test.js
@@ -1,4 +1,4 @@
-import {promises as fsPromises} from 'fs';
+import {promises as fs} from 'fs';
 import sinon from 'sinon';
 import {assert} from 'chai';
 import any from '@travi/any';
@@ -12,7 +12,7 @@ suite('babel config', () => {
   setup(() => {
     sandbox = sinon.createSandbox();
 
-    sandbox.stub(fsPromises, 'writeFile');
+    sandbox.stub(fs, 'writeFile');
   });
 
   teardown(() => sandbox.restore());
@@ -28,7 +28,7 @@ suite('babel config', () => {
     );
 
     assert.calledWith(
-      fsPromises.writeFile,
+      fs.writeFile,
       `${projectRoot}/.babelrc`,
       JSON.stringify({
         presets: [babelPresetName],
@@ -49,31 +49,14 @@ suite('babel config', () => {
     );
 
     assert.calledWith(
-      fsPromises.writeFile,
+      fs.writeFile,
       `${projectRoot}/.babelrc`,
       JSON.stringify({presets: [babelPresetName], ignore: [`./${buildDirectory}/`]})
     );
   });
 
   test('that the babelrc is not written if a preset is not defined', async () => {
-    assert.deepEqual(
-      await scaffoldBabel({preset: undefined, projectRoot}),
-      {
-        devDependencies: [],
-        scripts: {},
-        vcsIgnore: {files: [], directories: []}
-      }
-    );
-
-    assert.notCalled(fsPromises.writeFile);
-  });
-
-  test('that scaffolding is skipped if `transpileLint` is false', async () => {
-    assert.deepEqual(
-      await scaffoldBabel({preset: any.simpleObject(), projectRoot, transpileLint: false}),
-      {devDependencies: [], scripts: {}, vcsIgnore: {files: [], directories: []}}
-    );
-
-    assert.notCalled(fsPromises.writeFile);
+    assert.deepEqual(await scaffoldBabel({preset: undefined, projectRoot}), {});
+    assert.notCalled(fs.writeFile);
   });
 });

--- a/src/dialects/babel-test.js
+++ b/src/dialects/babel-test.js
@@ -55,8 +55,14 @@ suite('babel config', () => {
     );
   });
 
-  test('that the babelrc is not written if a preset is not defined', async () => {
-    assert.deepEqual(await scaffoldBabel({preset: undefined, projectRoot}), {});
-    assert.notCalled(fs.writeFile);
+  test('that an error is thrown if a preset is not defined', async () => {
+    try {
+      await scaffoldBabel({preset: undefined, projectRoot});
+
+      throw new Error('test should have failed, but didnt');
+    } catch (e) {
+      assert.notCalled(fs.writeFile);
+      assert.equal(e.message, 'No babel preset provided. Cannot configure babel transpilation');
+    }
   });
 });

--- a/src/dialects/babel.js
+++ b/src/dialects/babel.js
@@ -1,11 +1,8 @@
 import {promises as fsPromises} from 'fs';
-import {warn} from '@travi/cli-messages';
 
 export default async function ({projectRoot, preset, tests, buildDirectory}) {
   if (!preset) {
-    warn('Not configuring transpilation');
-
-    return {};
+    throw new Error('No babel preset provided. Cannot configure babel transpilation');
   }
 
   await fsPromises.writeFile(

--- a/src/dialects/babel.js
+++ b/src/dialects/babel.js
@@ -1,11 +1,11 @@
 import {promises as fsPromises} from 'fs';
 import {warn} from '@travi/cli-messages';
 
-export default async function ({projectRoot, preset, transpileLint, tests, buildDirectory}) {
-  if (false === transpileLint || !preset) {
+export default async function ({projectRoot, preset, tests, buildDirectory}) {
+  if (!preset) {
     warn('Not configuring transpilation');
 
-    return {devDependencies: [], scripts: {}, vcsIgnore: {files: [], directories: []}};
+    return {};
   }
 
   await fsPromises.writeFile(

--- a/src/dialects/prompt-choices-test.js
+++ b/src/dialects/prompt-choices-test.js
@@ -4,6 +4,12 @@ import buildDialectChoices from './prompt-choices';
 
 suite('dialect prompt questions', () => {
   test('that the available dialects are listed', () => {
-    assert.deepEqual(buildDialectChoices(), [dialects.COMMON_JS, dialects.BABEL]);
+    assert.deepEqual(
+      buildDialectChoices(),
+      [
+        {name: 'Common JS (no transpilation)', value: dialects.COMMON_JS, short: 'cjs'},
+        {name: 'Modern JavaScript (transpiled)', value: dialects.BABEL, short: 'modern'}
+      ]
+    );
   });
 });

--- a/src/dialects/prompt-choices-test.js
+++ b/src/dialects/prompt-choices-test.js
@@ -1,15 +1,23 @@
 import {dialects} from '@form8ion/javascript-core';
 import {assert} from 'chai';
+import any from '@travi/any';
 import buildDialectChoices from './prompt-choices';
 
 suite('dialect prompt questions', () => {
   test('that the available dialects are listed', () => {
     assert.deepEqual(
-      buildDialectChoices(),
+      buildDialectChoices({...any.simpleObject(), babelPreset: any.simpleObject()}),
       [
         {name: 'Common JS (no transpilation)', value: dialects.COMMON_JS, short: 'cjs'},
         {name: 'Modern JavaScript (transpiled)', value: dialects.BABEL, short: 'modern'}
       ]
+    );
+  });
+
+  test('that `babel` is not included in the choices list when a preset is not provided', () => {
+    assert.deepEqual(
+      buildDialectChoices(any.simpleObject()),
+      [{name: 'Common JS (no transpilation)', value: dialects.COMMON_JS, short: 'cjs'}]
     );
   });
 });

--- a/src/dialects/prompt-choices-test.js
+++ b/src/dialects/prompt-choices-test.js
@@ -1,0 +1,9 @@
+import {dialects} from '@form8ion/javascript-core';
+import {assert} from 'chai';
+import buildDialectChoices from './prompt-choices';
+
+suite('dialect prompt questions', () => {
+  test('that the available dialects are listed', () => {
+    assert.deepEqual(buildDialectChoices(), [dialects.COMMON_JS, dialects.BABEL]);
+  });
+});

--- a/src/dialects/prompt-choices.js
+++ b/src/dialects/prompt-choices.js
@@ -1,8 +1,8 @@
 import {dialects} from '@form8ion/javascript-core';
 
-export default function () {
+export default function ({babelPreset}) {
   return [
     {name: 'Common JS (no transpilation)', value: dialects.COMMON_JS, short: 'cjs'},
-    {name: 'Modern JavaScript (transpiled)', value: dialects.BABEL, short: 'modern'}
+    ...babelPreset ? [{name: 'Modern JavaScript (transpiled)', value: dialects.BABEL, short: 'modern'}] : []
   ];
 }

--- a/src/dialects/prompt-choices.js
+++ b/src/dialects/prompt-choices.js
@@ -1,0 +1,5 @@
+import {dialects} from '@form8ion/javascript-core';
+
+export default function () {
+  return [dialects.COMMON_JS, dialects.BABEL];
+}

--- a/src/dialects/prompt-choices.js
+++ b/src/dialects/prompt-choices.js
@@ -1,5 +1,8 @@
 import {dialects} from '@form8ion/javascript-core';
 
 export default function () {
-  return [dialects.COMMON_JS, dialects.BABEL];
+  return [
+    {name: 'Common JS (no transpilation)', value: dialects.COMMON_JS, short: 'cjs'},
+    {name: 'Modern JavaScript (transpiled)', value: dialects.BABEL, short: 'modern'}
+  ];
 }

--- a/src/dialects/scaffolder-test.js
+++ b/src/dialects/scaffolder-test.js
@@ -1,3 +1,4 @@
+import {dialects} from '@form8ion/javascript-core';
 import sinon from 'sinon';
 import any from '@travi/any';
 import {assert} from 'chai';
@@ -24,7 +25,7 @@ suite('scaffold dialect', () => {
     babel.default.withArgs({preset: babelPreset, projectRoot, tests, buildDirectory}).resolves(babelResults);
 
     assert.equal(
-      await scaffoldDialect({dialect: 'babel', configs: {babelPreset}, projectRoot, tests, buildDirectory}),
+      await scaffoldDialect({dialect: dialects.BABEL, configs: {babelPreset}, projectRoot, tests, buildDirectory}),
       babelResults
     );
   });

--- a/src/dialects/scaffolder-test.js
+++ b/src/dialects/scaffolder-test.js
@@ -18,23 +18,13 @@ suite('scaffold dialect', () => {
 
   test('that babel is scaffolded when chosen', async () => {
     const babelPreset = any.word();
-    const transpileLint = any.boolean();
     const tests = any.simpleObject();
     const buildDirectory = any.string();
     const babelResults = any.simpleObject();
-    babel.default
-      .withArgs({preset: babelPreset, projectRoot, transpileLint, tests, buildDirectory})
-      .resolves(babelResults);
+    babel.default.withArgs({preset: babelPreset, projectRoot, tests, buildDirectory}).resolves(babelResults);
 
     assert.equal(
-      await scaffoldDialect({
-        dialect: 'babel',
-        configs: {babelPreset},
-        projectRoot,
-        transpileLint,
-        tests,
-        buildDirectory
-      }),
+      await scaffoldDialect({dialect: 'babel', configs: {babelPreset}, projectRoot, tests, buildDirectory}),
       babelResults
     );
   });

--- a/src/dialects/scaffolder-test.js
+++ b/src/dialects/scaffolder-test.js
@@ -16,7 +16,7 @@ suite('scaffold dialect', () => {
 
   teardown(() => sandbox.restore());
 
-  test('that the details of the chosen dialect are scaffolded', async () => {
+  test('that babel is scaffolded when chosen', async () => {
     const babelPreset = any.word();
     const transpileLint = any.boolean();
     const tests = any.simpleObject();
@@ -27,8 +27,20 @@ suite('scaffold dialect', () => {
       .resolves(babelResults);
 
     assert.equal(
-      await scaffoldDialect({configs: {babelPreset}, projectRoot, transpileLint, tests, buildDirectory}),
+      await scaffoldDialect({
+        dialect: 'babel',
+        configs: {babelPreset},
+        projectRoot,
+        transpileLint,
+        tests,
+        buildDirectory
+      }),
       babelResults
     );
+  });
+
+  test('that babel is not scaffolded when not chosen', async () => {
+    assert.deepEqual(await scaffoldDialect({dialect: any.word()}), {});
+    assert.notCalled(babel.default);
   });
 });

--- a/src/dialects/scaffolder.js
+++ b/src/dialects/scaffolder.js
@@ -1,7 +1,8 @@
+import {dialects} from '@form8ion/javascript-core';
 import scaffoldBabel from './babel';
 
 export default function ({dialect, projectRoot, configs, tests, buildDirectory}) {
-  if ('babel' === dialect) {
+  if (dialects.BABEL === dialect) {
     return scaffoldBabel({preset: configs.babelPreset, projectRoot, tests, buildDirectory});
   }
 

--- a/src/dialects/scaffolder.js
+++ b/src/dialects/scaffolder.js
@@ -1,5 +1,9 @@
 import scaffoldBabel from './babel';
 
-export default function ({projectRoot, configs, transpileLint, tests, buildDirectory}) {
-  return scaffoldBabel({preset: configs.babelPreset, projectRoot, transpileLint, tests, buildDirectory});
+export default function ({dialect, projectRoot, configs, transpileLint, tests, buildDirectory}) {
+  if ('babel' === dialect) {
+    return scaffoldBabel({preset: configs.babelPreset, projectRoot, transpileLint, tests, buildDirectory});
+  }
+
+  return {};
 }

--- a/src/dialects/scaffolder.js
+++ b/src/dialects/scaffolder.js
@@ -1,8 +1,8 @@
 import scaffoldBabel from './babel';
 
-export default function ({dialect, projectRoot, configs, transpileLint, tests, buildDirectory}) {
+export default function ({dialect, projectRoot, configs, tests, buildDirectory}) {
   if ('babel' === dialect) {
-    return scaffoldBabel({preset: configs.babelPreset, projectRoot, transpileLint, tests, buildDirectory});
+    return scaffoldBabel({preset: configs.babelPreset, projectRoot, tests, buildDirectory});
   }
 
   return {};

--- a/src/linting/remark-test.js
+++ b/src/linting/remark-test.js
@@ -93,6 +93,7 @@ exports.plugins = [
         projectRoot,
         projectType: projectTypes.PACKAGE,
         vcs: any.simpleObject(),
+        configureLinting: true,
         dialect: dialects.BABEL
       })).scripts,
       {

--- a/src/linting/remark-test.js
+++ b/src/linting/remark-test.js
@@ -1,5 +1,5 @@
 import {promises as fsPromises} from 'fs';
-import {projectTypes} from '@form8ion/javascript-core';
+import {dialects, projectTypes} from '@form8ion/javascript-core';
 import {assert} from 'chai';
 import any from '@travi/any';
 import sinon from 'sinon';
@@ -51,7 +51,13 @@ exports.plugins = [
     const projectRoot = any.string();
 
     assert.deepEqual(
-      await scaffoldRemark({config, projectRoot, projectType: projectTypes.PACKAGE, vcs: any.simpleObject()}),
+      await scaffoldRemark({
+        config,
+        projectRoot,
+        dialect: dialects.COMMON_JS,
+        projectType: projectTypes.PACKAGE,
+        vcs: any.simpleObject()
+      }),
       {
         devDependencies: [config, 'remark-cli', 'remark-toc', 'remark-usage'],
         scripts: {'lint:md': 'remark . --frail', 'generate:md': 'remark . --output'}
@@ -87,7 +93,7 @@ exports.plugins = [
         projectRoot,
         projectType: projectTypes.PACKAGE,
         vcs: any.simpleObject(),
-        transpileLint: true
+        dialect: dialects.BABEL
       })).scripts,
       {
         'lint:md': 'remark . --frail',

--- a/src/linting/remark.js
+++ b/src/linting/remark.js
@@ -1,8 +1,8 @@
 import {promises as fsPromises} from 'fs';
 import deepmerge from 'deepmerge';
-import {projectTypes} from '@form8ion/javascript-core';
+import {dialects, projectTypes} from '@form8ion/javascript-core';
 
-export default async function ({config, projectRoot, projectType, vcs, transpileLint}) {
+export default async function ({config, projectRoot, projectType, vcs, dialect}) {
   await fsPromises.writeFile(
     `${projectRoot}/.remarkrc.js`,
     `// https://github.com/remarkjs/remark/tree/master/packages/remark-stringify#options
@@ -41,7 +41,7 @@ exports.plugins = [
     {
       ...projectTypes.PACKAGE === projectType && {
         devDependencies: ['remark-usage'],
-        ...transpileLint && {scripts: {'pregenerate:md': 'run-s build'}}
+        ...dialects.COMMON_JS !== dialect && {scripts: {'pregenerate:md': 'run-s build'}}
       }
     }
   );

--- a/src/linting/scaffolder-test.js
+++ b/src/linting/scaffolder-test.js
@@ -28,6 +28,7 @@ suite('linting scaffolder', () => {
   const buildDirectory = any.string();
   const eslintConfigs = any.listOf(any.word);
   const transpileLint = true;
+  const dialect = any.word();
 
   setup(() => {
     sandbox = sinon.createSandbox();
@@ -38,7 +39,7 @@ suite('linting scaffolder', () => {
     sandbox.stub(scaffoldLockfileLint, 'default');
 
     scaffoldRemark.default
-      .withArgs({projectRoot, projectType, config: configForRemark, vcs, transpileLint})
+      .withArgs({projectRoot, projectType, config: configForRemark, vcs, dialect})
       .resolves({devDependencies: remarkDevDependencies, scripts: remarkScripts});
     scaffoldEslint.default
       .withArgs({
@@ -65,6 +66,7 @@ suite('linting scaffolder', () => {
     const result = await scaffold({
       projectRoot,
       projectType,
+      dialect,
       configs: {eslint: configForEslint, remark: configForRemark},
       vcs,
       buildDirectory,
@@ -99,6 +101,7 @@ suite('linting scaffolder', () => {
     const result = await scaffold({
       projectRoot,
       projectType,
+      dialect,
       configs: {remark: configForRemark},
       vcs,
       transpileLint,
@@ -121,6 +124,7 @@ suite('linting scaffolder', () => {
     const result = await scaffold({
       projectRoot,
       projectType,
+      dialect,
       configs: {eslint: configForEslint, remark: configForRemark},
       vcs,
       transpileLint: false,
@@ -137,12 +141,13 @@ suite('linting scaffolder', () => {
 
   test('that remark defaults to the form8ion config when a config is not defined', async () => {
     scaffoldRemark.default
-      .withArgs({projectRoot, projectType, vcs, transpileLint, config: '@form8ion/remark-lint-preset'})
+      .withArgs({projectRoot, projectType, vcs, dialect, config: '@form8ion/remark-lint-preset'})
       .resolves({devDependencies: remarkDevDependencies, scripts: remarkScripts});
 
     const result = await scaffold({
       projectRoot,
       projectType,
+      dialect,
       configs: {eslint: configForEslint},
       vcs,
       buildDirectory,
@@ -175,12 +180,13 @@ suite('linting scaffolder', () => {
 
   test('that ban-sensitive-files is not scaffolded when the project will not be versioned', async () => {
     scaffoldRemark.default
-      .withArgs({projectRoot, projectType, config: configForRemark, vcs: undefined, transpileLint})
+      .withArgs({projectRoot, projectType, config: configForRemark, vcs: undefined, dialect})
       .resolves({devDependencies: remarkDevDependencies, scripts: remarkScripts});
 
     const result = await scaffold({
       projectRoot,
       projectType,
+      dialect,
       configs: {eslint: configForEslint, remark: configForRemark},
       vcs: undefined,
       buildDirectory,

--- a/src/linting/scaffolder-test.js
+++ b/src/linting/scaffolder-test.js
@@ -27,7 +27,7 @@ suite('linting scaffolder', () => {
   const registries = any.simpleObject();
   const buildDirectory = any.string();
   const eslintConfigs = any.listOf(any.word);
-  const transpileLint = true;
+  const configureLinting = true;
   const dialect = any.word();
 
   setup(() => {
@@ -71,7 +71,7 @@ suite('linting scaffolder', () => {
       vcs,
       buildDirectory,
       eslint: {configs: eslintConfigs},
-      transpileLint,
+      configureLinting,
       packageManager,
       registries
     });
@@ -104,7 +104,7 @@ suite('linting scaffolder', () => {
       dialect,
       configs: {remark: configForRemark},
       vcs,
-      transpileLint,
+      configureLinting,
       packageManager,
       registries
     });
@@ -118,7 +118,7 @@ suite('linting scaffolder', () => {
 
   test('that eslint is not scaffolded when `transpileLint` is false', async () => {
     scaffoldRemark.default
-      .withArgs({projectRoot, projectType, config: configForRemark, vcs, transpileLint: false})
+      .withArgs({projectRoot, projectType, config: configForRemark, vcs, configureLinting: false})
       .resolves({devDependencies: remarkDevDependencies, scripts: remarkScripts});
 
     const result = await scaffold({
@@ -127,7 +127,7 @@ suite('linting scaffolder', () => {
       dialect,
       configs: {eslint: configForEslint, remark: configForRemark},
       vcs,
-      transpileLint: false,
+      configureLinting: false,
       packageManager,
       registries
     });
@@ -152,7 +152,7 @@ suite('linting scaffolder', () => {
       vcs,
       buildDirectory,
       eslint: {configs: eslintConfigs},
-      transpileLint,
+      configureLinting,
       packageManager,
       registries
     });
@@ -191,7 +191,7 @@ suite('linting scaffolder', () => {
       vcs: undefined,
       buildDirectory,
       eslint: {configs: eslintConfigs},
-      transpileLint,
+      configureLinting,
       packageManager,
       registries
     });

--- a/src/linting/scaffolder.js
+++ b/src/linting/scaffolder.js
@@ -8,6 +8,7 @@ export default async function ({
   projectRoot,
   projectType,
   packageManager,
+  dialect,
   registries,
   configs,
   vcs,
@@ -28,8 +29,8 @@ export default async function ({
     scaffoldRemark({
       projectRoot,
       projectType,
+      dialect,
       vcs,
-      transpileLint,
       config: configs.remark || '@form8ion/remark-lint-preset'
     }),
     vcs ? scaffoldBanSensitiveFiles() : {}

--- a/src/linting/scaffolder.js
+++ b/src/linting/scaffolder.js
@@ -12,13 +12,13 @@ export default async function ({
   registries,
   configs,
   vcs,
-  transpileLint,
+  configureLinting,
   buildDirectory,
   eslint
 }) {
   return deepmerge.all(await Promise.all([
     scaffoldLockfileLint({projectRoot, packageManager, registries}),
-    configs.eslint && false !== transpileLint
+    configs.eslint && configureLinting
       ? scaffoldEslint({
         projectRoot,
         config: configs.eslint,

--- a/src/project-type/application-test.js
+++ b/src/project-type/application-test.js
@@ -99,18 +99,4 @@ suite('application project-type', () => {
       }
     );
   });
-
-  test('that build details are not included when the project will not be transpiled', async () => {
-    assert.deepEqual(
-      await scaffoldApplication({projectRoot, applicationTypes, transpileLint: false}),
-      {
-        scripts: {},
-        dependencies: [],
-        devDependencies: [],
-        vcsIgnore: {files: [], directories: []},
-        eslintConfigs: [],
-        nextSteps: []
-      }
-    );
-  });
 });

--- a/src/project-type/application.js
+++ b/src/project-type/application.js
@@ -11,47 +11,35 @@ export default async function ({
   projectName,
   packageName,
   packageManager,
-  transpileLint,
   tests,
   decisions
 }) {
   info('Scaffolding Application Details');
 
-  if (false !== transpileLint) {
-    const chosenType = await chooseApplicationType({types: applicationTypes, projectType: 'application', decisions});
-    const results = await scaffoldChosenApplicationType(
-      applicationTypes,
-      chosenType,
-      {projectRoot, projectName, packageName, packageManager, tests}
-    );
+  const chosenType = await chooseApplicationType({types: applicationTypes, projectType: 'application', decisions});
+  const results = await scaffoldChosenApplicationType(
+    applicationTypes,
+    chosenType,
+    {projectRoot, projectName, packageName, packageManager, tests}
+  );
 
-    const buildDirectory = results.buildDirectory || defaultBuildDirectory;
+  const buildDirectory = results.buildDirectory || defaultBuildDirectory;
 
-    return deepmerge(
-      {
-        scripts: {
-          clean: `rimraf ./${buildDirectory}`,
-          start: `node ./${buildDirectory}/index.js`,
-          prebuild: 'run-s clean'
-        },
-        dependencies: [],
-        devDependencies: ['rimraf'],
-        vcsIgnore: {files: ['.env'], directories: [`/${buildDirectory}/`]},
-        buildDirectory,
-        packageProperties: {private: true},
-        eslintConfigs: [],
-        nextSteps: []
+  return deepmerge(
+    {
+      scripts: {
+        clean: `rimraf ./${buildDirectory}`,
+        start: `node ./${buildDirectory}/index.js`,
+        prebuild: 'run-s clean'
       },
-      results
-    );
-  }
-
-  return {
-    dependencies: [],
-    devDependencies: [],
-    scripts: {},
-    vcsIgnore: {files: [], directories: []},
-    eslintConfigs: [],
-    nextSteps: []
-  };
+      dependencies: [],
+      devDependencies: ['rimraf'],
+      vcsIgnore: {files: ['.env'], directories: [`/${buildDirectory}/`]},
+      buildDirectory,
+      packageProperties: {private: true},
+      eslintConfigs: [],
+      nextSteps: []
+    },
+    results
+  );
 }

--- a/src/project-type/package/scaffolder-test.js
+++ b/src/project-type/package/scaffolder-test.js
@@ -101,7 +101,8 @@ suite('package project-type', () => {
         scope,
         packageTypes,
         tests,
-        decisions
+        decisions,
+        dialect: jsCore.dialects.BABEL
       }),
       {
         ...rollupResults,
@@ -165,7 +166,8 @@ suite('package project-type', () => {
       packageTypes,
       tests,
       decisions,
-      scope
+      scope,
+      dialect: jsCore.dialects.BABEL
     });
 
     assert.deepEqual(
@@ -198,7 +200,6 @@ suite('package project-type', () => {
     assert.deepEqual(
       await scaffoldPackage({
         projectRoot,
-        transpileLint: false,
         packageName,
         projectName,
         packageManager,
@@ -206,7 +207,8 @@ suite('package project-type', () => {
         scope,
         decisions,
         packageTypes,
-        tests
+        tests,
+        dialect: jsCore.dialects.COMMON_JS
       }),
       {
         dependencies: scaffoldedTypeDependencies,

--- a/src/project-type/package/scaffolder.js
+++ b/src/project-type/package/scaffolder.js
@@ -2,7 +2,7 @@ import {promises as fs} from 'fs';
 import deepmerge from 'deepmerge';
 import mustache from 'mustache';
 import {fileExists} from '@form8ion/core';
-import {scaffoldChoice as scaffoldChosenPackageType} from '@form8ion/javascript-core';
+import {scaffoldChoice as scaffoldChosenPackageType, dialects} from '@form8ion/javascript-core';
 import {info} from '@travi/cli-messages';
 import camelcase from '../../../third-party-wrappers/camelcase';
 import touch from '../../../third-party-wrappers/touch';
@@ -77,7 +77,6 @@ async function buildDetailsForNonTranspiledProject(projectRoot, projectName) {
 
 export default async function ({
   projectRoot,
-  transpileLint,
   projectName,
   packageName,
   packageManager,
@@ -85,12 +84,13 @@ export default async function ({
   scope,
   packageTypes,
   tests,
-  decisions
+  decisions,
+  dialect
 }) {
   info('Scaffolding Package Details');
 
   const details = {
-    ...false !== transpileLint && {
+    ...dialects.BABEL === dialect && {
       packageProperties: {
         main: 'lib/index.cjs.js',
         module: 'lib/index.es.js',
@@ -107,7 +107,7 @@ export default async function ({
         packageName
       )
     },
-    ...false === transpileLint && {
+    ...dialects.COMMON_JS === dialect && {
       packageProperties: {files: ['index.js']},
       ...await buildDetailsForNonTranspiledProject(projectRoot, projectName)
     }

--- a/src/project-type/package/scaffolder.js
+++ b/src/project-type/package/scaffolder.js
@@ -1,8 +1,7 @@
 import {promises as fs} from 'fs';
 import deepmerge from 'deepmerge';
 import mustache from 'mustache';
-import {fileExists} from '@form8ion/core';
-import {scaffoldChoice as scaffoldChosenPackageType, dialects} from '@form8ion/javascript-core';
+import {dialects, scaffoldChoice as scaffoldChosenPackageType} from '@form8ion/javascript-core';
 import {info} from '@travi/cli-messages';
 import camelcase from '../../../third-party-wrappers/camelcase';
 import touch from '../../../third-party-wrappers/touch';
@@ -18,17 +17,13 @@ const defaultBuildDirectory = 'lib';
 async function createExample(projectRoot, projectName) {
   const pathToExample = `${projectRoot}/example.js`;
 
-  if (!await fileExists(pathToExample)) {
-    return fs.writeFile(
-      pathToExample,
-      mustache.render(
-        await fs.readFile(determinePathToTemplateFile('example.mustache'), 'utf8'),
-        {projectName: camelcase(projectName)}
-      )
-    );
-  }
-
-  return undefined;
+  return fs.writeFile(
+    pathToExample,
+    mustache.render(
+      await fs.readFile(determinePathToTemplateFile('example.mustache'), 'utf8'),
+      {projectName: camelcase(projectName)}
+    )
+  );
 }
 
 async function buildDetails(packageTypes, decisions, projectRoot, tests, projectName, visibility, packageName) {

--- a/src/project-type/scaffolder-test.js
+++ b/src/project-type/scaffolder-test.js
@@ -37,12 +37,12 @@ suite('project-type scaffolder', () => {
   test('that the package-type scaffolder is applied when the project-type is `Package`', async () => {
     const scope = any.word();
     const packageManager = any.word();
+    const dialect = any.word();
     const packageTypes = any.simpleObject();
 
     packageTypeScaffolder.default
       .withArgs({
         projectRoot,
-        transpileLint,
         packageName,
         projectName,
         packageManager,
@@ -51,7 +51,8 @@ suite('project-type scaffolder', () => {
         packageTypes,
         tests,
         vcs,
-        decisions
+        decisions,
+        dialect
       })
       .resolves(results);
 
@@ -68,7 +69,8 @@ suite('project-type scaffolder', () => {
         packageTypes,
         tests,
         vcs,
-        decisions
+        decisions,
+        dialect
       }),
       {
         ...commonDetails,

--- a/src/project-type/scaffolder-test.js
+++ b/src/project-type/scaffolder-test.js
@@ -12,7 +12,6 @@ suite('project-type scaffolder', () => {
   let sandbox;
   const results = any.simpleObject();
   const projectRoot = any.string();
-  const transpileLint = any.boolean();
   const projectName = any.word();
   const packageName = any.word();
   const packageManager = any.word();
@@ -60,7 +59,6 @@ suite('project-type scaffolder', () => {
       await projectTypeScaffolder({
         projectType: projectTypes.PACKAGE,
         projectRoot,
-        transpileLint,
         projectName,
         packageName,
         packageManager,
@@ -87,7 +85,6 @@ suite('project-type scaffolder', () => {
         projectName,
         packageName,
         packageManager,
-        transpileLint,
         applicationTypes,
         tests,
         decisions
@@ -101,7 +98,6 @@ suite('project-type scaffolder', () => {
         projectName,
         packageName,
         packageManager,
-        transpileLint,
         applicationTypes,
         tests,
         decisions,

--- a/src/project-type/scaffolder.js
+++ b/src/project-type/scaffolder.js
@@ -18,7 +18,8 @@ export default async function ({
   scope,
   tests,
   vcs,
-  decisions
+  decisions,
+  dialect
 }) {
   switch (projectType) {
     case projectTypes.PACKAGE:
@@ -26,7 +27,6 @@ export default async function ({
         buildCommonDetails(visibility, vcs),
         await scaffoldPackageType({
           projectRoot,
-          transpileLint,
           projectName,
           packageName,
           packageManager,
@@ -35,7 +35,8 @@ export default async function ({
           packageTypes,
           tests,
           vcs,
-          decisions
+          decisions,
+          dialect
         })
       );
     case projectTypes.APPLICATION:

--- a/src/project-type/scaffolder.js
+++ b/src/project-type/scaffolder.js
@@ -11,7 +11,6 @@ export default async function ({
   projectName,
   packageName,
   packageManager,
-  transpileLint,
   visibility,
   applicationTypes,
   packageTypes,
@@ -48,7 +47,6 @@ export default async function ({
           packageName,
           packageManager,
           applicationTypes,
-          transpileLint,
           tests,
           decisions
         })

--- a/src/prompts/conditionals-test.js
+++ b/src/prompts/conditionals-test.js
@@ -6,7 +6,7 @@ import {
   projectIsApplication,
   shouldBeScopedPromptShouldBePresented,
   scopePromptShouldBePresentedFactory,
-  transpilationAndLintingPromptShouldBePresented
+  lintingPromptShouldBePresented
 } from './conditionals';
 import {questionNames} from './question-names';
 
@@ -75,15 +75,15 @@ suite('javascript prompt conditionals', () => {
 
   suite('transpilation/linting', () => {
     test('that the prompt is not shown if the project is unit tested', () => {
-      assert.isFalse(transpilationAndLintingPromptShouldBePresented({[commonQuestionNames.UNIT_TESTS]: true}));
+      assert.isFalse(lintingPromptShouldBePresented({[commonQuestionNames.UNIT_TESTS]: true}));
     });
 
     test('that the prompt is not shown if the project is integration tested', () => {
-      assert.isFalse(transpilationAndLintingPromptShouldBePresented({[commonQuestionNames.INTEGRATION_TESTS]: true}));
+      assert.isFalse(lintingPromptShouldBePresented({[commonQuestionNames.INTEGRATION_TESTS]: true}));
     });
 
     test('that the prompt is shown if the project is not tested', () => {
-      assert.isTrue(transpilationAndLintingPromptShouldBePresented({
+      assert.isTrue(lintingPromptShouldBePresented({
         [commonQuestionNames.INTEGRATION_TESTS]: false,
         [commonQuestionNames.UNIT_TESTS]: false
       }));

--- a/src/prompts/conditionals.js
+++ b/src/prompts/conditionals.js
@@ -30,7 +30,7 @@ export function scopePromptShouldBePresentedFactory(visibility) {
   return answers => willBePublishedToNpm(answers) && packageShouldBeScoped(visibility, answers);
 }
 
-export function transpilationAndLintingPromptShouldBePresented({
+export function lintingPromptShouldBePresented({
   [commonQuestionNames.UNIT_TESTS]: unitTested,
   [commonQuestionNames.INTEGRATION_TESTS]: integrationTested
 }) {

--- a/src/prompts/question-names.js
+++ b/src/prompts/question-names.js
@@ -9,6 +9,6 @@ export const questionNames = {
   AUTHOR_EMAIL: 'authorEmail',
   AUTHOR_URL: 'authorUrl',
   HOST: 'host',
-  TRANSPILE_LINT: 'transpileLint',
+  CONFIGURE_LINTING: 'configureLint',
   DIALECT: 'dialect'
 };

--- a/src/prompts/question-names.js
+++ b/src/prompts/question-names.js
@@ -9,5 +9,6 @@ export const questionNames = {
   AUTHOR_EMAIL: 'authorEmail',
   AUTHOR_URL: 'authorUrl',
   HOST: 'host',
-  TRANSPILE_LINT: 'transpileLint'
+  TRANSPILE_LINT: 'transpileLint',
+  DIALECT: 'dialect'
 };

--- a/src/prompts/questions-test.js
+++ b/src/prompts/questions-test.js
@@ -1,4 +1,4 @@
-import inquirer from 'inquirer';
+import inquirer, {Separator} from 'inquirer';
 import * as prompts from '@form8ion/overridable-prompts';
 import {projectTypes, packageManagers, dialects} from '@form8ion/javascript-core';
 import * as commonPrompts from '@travi/language-scaffolder-prompts';
@@ -88,7 +88,7 @@ suite('prompts', () => {
           name: questionNames.PROJECT_TYPE,
           message: 'What type of JavaScript project is this?',
           type: 'list',
-          choices: Object.values(projectTypes),
+          choices: [...Object.values(projectTypes), new Separator(), 'Other'],
           default: projectTypes.PACKAGE
         },
         {

--- a/src/prompts/questions-test.js
+++ b/src/prompts/questions-test.js
@@ -54,6 +54,7 @@ suite('prompts', () => {
     const filteredCiServices = any.objectWithKeys(filteredCiServiceNames);
     const hosts = any.simpleObject();
     const dialects = any.listOf(any.simpleObject);
+    const configs = any.simpleObject();
     const scopeValidator = () => undefined;
     const scopePromptShouldBePresented = () => undefined;
     npmConf.default.returns({get});
@@ -64,7 +65,7 @@ suite('prompts', () => {
     validators.scope.withArgs(visibility).returns(scopeValidator);
     conditionals.scopePromptShouldBePresentedFactory.withArgs(visibility).returns(scopePromptShouldBePresented);
     visibilityFilterForChoices.default.withArgs(ciServices, visibility).returns(filteredCiServices);
-    dialectChoices.default.returns(dialects);
+    dialectChoices.default.withArgs(configs).returns(dialects);
     prompts.prompt
       .withArgs([
         {
@@ -142,7 +143,7 @@ suite('prompts', () => {
       .resolves(answers);
 
     assert.deepEqual(
-      await prompt({}, ciServices, hosts, visibility, vcs, decisions),
+      await prompt({}, ciServices, hosts, visibility, vcs, decisions, configs),
       {...answers, [questionNames.TRANSPILE_LINT]: true}
     );
   });
@@ -203,7 +204,7 @@ suite('prompts', () => {
       .returns(commonQuestions);
     prompts.prompt.resolves(answers);
 
-    await prompt({}, ciServices, {}, 'Private', vcs, null, pathWithinParent);
+    await prompt({}, ciServices, {}, 'Private', vcs, null, null, pathWithinParent);
 
     assert.neverCalledWith(
       prompts.prompt,
@@ -219,7 +220,7 @@ suite('prompts', () => {
       .returns(commonQuestions);
     prompts.prompt.resolves(answers);
 
-    await prompt({}, ciServices, {}, 'Private', vcs, null, pathWithinParent);
+    await prompt({}, ciServices, {}, 'Private', vcs, null, null, pathWithinParent);
 
     assert.neverCalledWith(
       prompts.prompt,
@@ -235,7 +236,7 @@ suite('prompts', () => {
       .returns(commonQuestions);
     prompts.prompt.resolves(answers);
 
-    await prompt({}, ciServices, {}, 'Public', vcs, null, pathWithinParent);
+    await prompt({}, ciServices, {}, 'Public', vcs, null, null, pathWithinParent);
 
     assert.calledWith(
       prompts.prompt,

--- a/src/prompts/questions-test.js
+++ b/src/prompts/questions-test.js
@@ -1,12 +1,13 @@
 import inquirer, {Separator} from 'inquirer';
 import * as prompts from '@form8ion/overridable-prompts';
-import {projectTypes, packageManagers, dialects} from '@form8ion/javascript-core';
+import {packageManagers, projectTypes} from '@form8ion/javascript-core';
 import * as commonPrompts from '@travi/language-scaffolder-prompts';
 import sinon from 'sinon';
 import {assert} from 'chai';
 import any from '@travi/any';
 import * as execa from '../../third-party-wrappers/execa';
 import * as npmConf from '../../third-party-wrappers/npm-conf';
+import * as dialectChoices from '../dialects/prompt-choices';
 import * as validators from './validators';
 import * as conditionals from './conditionals';
 import * as visibilityFilterForChoices from './filter-by-visibility';
@@ -33,6 +34,7 @@ suite('prompts', () => {
     sandbox.stub(conditionals, 'scopePromptShouldBePresentedFactory');
     sandbox.stub(visibilityFilterForChoices, 'default');
     sandbox.stub(commonPrompts, 'questions');
+    sandbox.stub(dialectChoices, 'default');
 
     visibilityFilterForChoices.default.withArgs({}).returns({});
     commonPrompts.questions
@@ -51,6 +53,7 @@ suite('prompts', () => {
     const filteredCiServiceNames = any.listOf(any.word);
     const filteredCiServices = any.objectWithKeys(filteredCiServiceNames);
     const hosts = any.simpleObject();
+    const dialects = any.listOf(any.simpleObject);
     const scopeValidator = () => undefined;
     const scopePromptShouldBePresented = () => undefined;
     npmConf.default.returns({get});
@@ -61,13 +64,14 @@ suite('prompts', () => {
     validators.scope.withArgs(visibility).returns(scopeValidator);
     conditionals.scopePromptShouldBePresentedFactory.withArgs(visibility).returns(scopePromptShouldBePresented);
     visibilityFilterForChoices.default.withArgs(ciServices, visibility).returns(filteredCiServices);
+    dialectChoices.default.returns(dialects);
     prompts.prompt
       .withArgs([
         {
           name: questionNames.DIALECT,
           message: 'Which JavaScript dialect should this project follow?',
           type: 'list',
-          choices: [dialects.COMMON_JS, dialects.BABEL],
+          choices: dialects,
           default: 'babel'
         },
         {

--- a/src/prompts/questions-test.js
+++ b/src/prompts/questions-test.js
@@ -127,10 +127,10 @@ suite('prompts', () => {
         },
         ...commonQuestions,
         {
-          name: questionNames.TRANSPILE_LINT,
-          message: 'Will there be source code that should be transpiled or linted?',
+          name: questionNames.CONFIGURE_LINTING,
+          message: 'Will there be source code that should be linted?',
           type: 'confirm',
-          when: conditionals.transpilationAndLintingPromptShouldBePresented
+          when: conditionals.lintingPromptShouldBePresented
         },
         {
           name: questionNames.HOST,
@@ -144,7 +144,7 @@ suite('prompts', () => {
 
     assert.deepEqual(
       await prompt({}, ciServices, hosts, visibility, vcs, decisions, configs),
-      {...answers, [questionNames.TRANSPILE_LINT]: true}
+      {...answers, [questionNames.CONFIGURE_LINTING]: true}
     );
   });
 
@@ -153,11 +153,11 @@ suite('prompts', () => {
     const get = sinon.stub();
     npmConf.default.returns({get});
     execa.default.withArgs('npm', ['whoami']).resolves({stdout: npmUser});
-    prompts.prompt.resolves({...answers, [questionNames.TRANSPILE_LINT]: false});
+    prompts.prompt.resolves({...answers, [questionNames.CONFIGURE_LINTING]: false});
 
     assert.deepEqual(
       await prompt({}, ciServices, {}, visibility, vcs, decisions),
-      {...answers, [questionNames.TRANSPILE_LINT]: false}
+      {...answers, [questionNames.CONFIGURE_LINTING]: false}
     );
   });
 

--- a/src/prompts/questions-test.js
+++ b/src/prompts/questions-test.js
@@ -64,6 +64,13 @@ suite('prompts', () => {
     prompts.prompt
       .withArgs([
         {
+          name: questionNames.DIALECT,
+          message: 'Which JavaScript dialect should this project follow?',
+          type: 'list',
+          choices: ['common-js', 'babel'],
+          default: 'babel'
+        },
+        {
           name: questionNames.NODE_VERSION_CATEGORY,
           message: 'What node.js version should be used?',
           type: 'list',

--- a/src/prompts/questions-test.js
+++ b/src/prompts/questions-test.js
@@ -1,6 +1,6 @@
 import inquirer from 'inquirer';
 import * as prompts from '@form8ion/overridable-prompts';
-import {projectTypes, packageManagers} from '@form8ion/javascript-core';
+import {projectTypes, packageManagers, dialects} from '@form8ion/javascript-core';
 import * as commonPrompts from '@travi/language-scaffolder-prompts';
 import sinon from 'sinon';
 import {assert} from 'chai';
@@ -67,7 +67,7 @@ suite('prompts', () => {
           name: questionNames.DIALECT,
           message: 'Which JavaScript dialect should this project follow?',
           type: 'list',
-          choices: ['common-js', 'babel'],
+          choices: [dialects.COMMON_JS, dialects.BABEL],
           default: 'babel'
         },
         {

--- a/src/prompts/questions.js
+++ b/src/prompts/questions.js
@@ -46,6 +46,13 @@ export async function prompt({npmAccount, author}, ciServices, hosts, visibility
   }
 
   const answers = await promptWithInquirer([
+    {
+      name: questionNames.DIALECT,
+      message: 'Which JavaScript dialect should this project follow?',
+      type: 'list',
+      choices: ['common-js', 'babel'],
+      default: 'babel'
+    },
     ...pathWithinParent ? [] : [{
       name: questionNames.NODE_VERSION_CATEGORY,
       message: 'What node.js version should be used?',

--- a/src/prompts/questions.js
+++ b/src/prompts/questions.js
@@ -1,5 +1,5 @@
 import {Separator} from 'inquirer';
-import {packageManagers, projectTypes} from '@form8ion/javascript-core';
+import {dialects, packageManagers, projectTypes} from '@form8ion/javascript-core';
 import {prompt as promptWithInquirer} from '@form8ion/overridable-prompts';
 import {questions as commonQuestions} from '@travi/language-scaffolder-prompts';
 import {warn} from '@travi/cli-messages';
@@ -50,7 +50,7 @@ export async function prompt({npmAccount, author}, ciServices, hosts, visibility
       name: questionNames.DIALECT,
       message: 'Which JavaScript dialect should this project follow?',
       type: 'list',
-      choices: ['common-js', 'babel'],
+      choices: [dialects.COMMON_JS, dialects.BABEL],
       default: 'babel'
     },
     ...pathWithinParent ? [] : [{

--- a/src/prompts/questions.js
+++ b/src/prompts/questions.js
@@ -1,16 +1,17 @@
 import {Separator} from 'inquirer';
-import {dialects, packageManagers, projectTypes} from '@form8ion/javascript-core';
+import {packageManagers, projectTypes} from '@form8ion/javascript-core';
 import {prompt as promptWithInquirer} from '@form8ion/overridable-prompts';
 import {questions as commonQuestions} from '@travi/language-scaffolder-prompts';
 import {warn} from '@travi/cli-messages';
 import execa from '../../third-party-wrappers/execa';
+import npmConfFactory from '../../third-party-wrappers/npm-conf';
+import buildDialectChoices from '../dialects/prompt-choices';
 import {
   projectIsApplication,
   scopePromptShouldBePresentedFactory,
   shouldBeScopedPromptShouldBePresented,
   transpilationAndLintingPromptShouldBePresented
 } from './conditionals';
-import npmConfFactory from '../../third-party-wrappers/npm-conf';
 import {questionNames} from './question-names';
 import {scope as validateScope} from './validators';
 
@@ -50,7 +51,7 @@ export async function prompt({npmAccount, author}, ciServices, hosts, visibility
       name: questionNames.DIALECT,
       message: 'Which JavaScript dialect should this project follow?',
       type: 'list',
-      choices: [dialects.COMMON_JS, dialects.BABEL],
+      choices: buildDialectChoices(),
       default: 'babel'
     },
     ...pathWithinParent ? [] : [{

--- a/src/prompts/questions.js
+++ b/src/prompts/questions.js
@@ -35,7 +35,16 @@ function authorQuestions({name, email, url}) {
   ];
 }
 
-export async function prompt({npmAccount, author}, ciServices, hosts, visibility, vcs, decisions, pathWithinParent) {
+export async function prompt(
+  {npmAccount, author},
+  ciServices,
+  hosts,
+  visibility,
+  vcs,
+  decisions,
+  configs,
+  pathWithinParent
+) {
   const npmConf = npmConfFactory();
 
   let maybeLoggedInNpmUsername;
@@ -51,7 +60,7 @@ export async function prompt({npmAccount, author}, ciServices, hosts, visibility
       name: questionNames.DIALECT,
       message: 'Which JavaScript dialect should this project follow?',
       type: 'list',
-      choices: buildDialectChoices(),
+      choices: buildDialectChoices(configs),
       default: 'babel'
     },
     ...pathWithinParent ? [] : [{

--- a/src/prompts/questions.js
+++ b/src/prompts/questions.js
@@ -10,7 +10,7 @@ import {
   projectIsApplication,
   scopePromptShouldBePresentedFactory,
   shouldBeScopedPromptShouldBePresented,
-  transpilationAndLintingPromptShouldBePresented
+  lintingPromptShouldBePresented
 } from './conditionals';
 import {questionNames} from './question-names';
 import {scope as validateScope} from './validators';
@@ -105,10 +105,10 @@ export async function prompt(
     }),
     ...commonQuestions(({vcs, ciServices, visibility, pathWithinParent})),
     {
-      name: questionNames.TRANSPILE_LINT,
-      message: 'Will there be source code that should be transpiled or linted?',
+      name: questionNames.CONFIGURE_LINTING,
+      message: 'Will there be source code that should be linted?',
       type: 'confirm',
-      when: transpilationAndLintingPromptShouldBePresented
+      when: lintingPromptShouldBePresented
     },
     {
       name: questionNames.HOST,
@@ -119,5 +119,8 @@ export async function prompt(
     }
   ], decisions);
 
-  return {...answers, ...false !== answers[questionNames.TRANSPILE_LINT] && {[questionNames.TRANSPILE_LINT]: true}};
+  return {
+    ...answers,
+    ...false !== answers[questionNames.CONFIGURE_LINTING] && {[questionNames.CONFIGURE_LINTING]: true}
+  };
 }

--- a/src/prompts/questions.js
+++ b/src/prompts/questions.js
@@ -71,7 +71,7 @@ export async function prompt({npmAccount, author}, ciServices, hosts, visibility
       name: questionNames.PROJECT_TYPE,
       message: 'What type of JavaScript project is this?',
       type: 'list',
-      choices: Object.values(projectTypes),
+      choices: [...Object.values(projectTypes), new Separator(), 'Other'],
       default: projectTypes.PACKAGE
     },
     ...'Private' === visibility ? [] : [{

--- a/src/scaffolder-test.js
+++ b/src/scaffolder-test.js
@@ -175,7 +175,7 @@ suite('javascript project scaffolder', () => {
       .resolves(projectTypeResults);
     packageScaffolder.default.withArgs(packageScaffoldingInputs).resolves({...any.simpleObject(), homepage});
     prompts.prompt
-      .withArgs(overrides, ciServices, hosts, visibility, vcsDetails, decisions, pathWithinParent)
+      .withArgs(overrides, ciServices, hosts, visibility, vcsDetails, decisions, configs, pathWithinParent)
       .resolves(commonPromptAnswers);
     jsCore.scaffoldChoice
       .withArgs(

--- a/src/scaffolder-test.js
+++ b/src/scaffolder-test.js
@@ -169,7 +169,8 @@ suite('javascript project scaffolder', () => {
         scope,
         tests,
         vcs: vcsDetails,
-        decisions
+        decisions,
+        dialect: chosenDialect
       })
       .resolves(projectTypeResults);
     packageScaffolder.default.withArgs(packageScaffoldingInputs).resolves({...any.simpleObject(), homepage});

--- a/src/scaffolder-test.js
+++ b/src/scaffolder-test.js
@@ -49,6 +49,7 @@ suite('javascript project scaffolder', () => {
   const babelResults = any.simpleObject();
   const npmResults = any.simpleObject();
   const chosenHost = any.word();
+  const chosenDialect = any.word();
   const projectType = any.word();
   const scope = any.word();
   const license = any.string();
@@ -128,7 +129,8 @@ suite('javascript project scaffolder', () => {
     [questionNames.HOST]: chosenHost,
     [questionNames.NODE_VERSION_CATEGORY]: versionCategory,
     [questionNames.TRANSPILE_LINT]: transpileLint,
-    [questionNames.PACKAGE_MANAGER]: packageManager
+    [questionNames.PACKAGE_MANAGER]: packageManager,
+    [questionNames.DIALECT]: chosenDialect
   };
 
   setup(() => {
@@ -209,7 +211,14 @@ suite('javascript project scaffolder', () => {
       })
       .resolves(lintingResults);
     dialects.default
-      .withArgs({projectRoot, configs, transpileLint, tests, buildDirectory: projectTypeBuildDirectory})
+      .withArgs({
+        projectRoot,
+        configs,
+        transpileLint,
+        tests,
+        buildDirectory: projectTypeBuildDirectory,
+        dialect: chosenDialect
+      })
       .resolves(babelResults);
     npmConfig.default.resolves(npmResults);
     commitConvention.default
@@ -254,7 +263,7 @@ suite('javascript project scaffolder', () => {
 
       assert.calledWith(
         dialects.default,
-        {configs, projectRoot, transpileLint, tests, buildDirectory: projectTypeBuildDirectory}
+        {configs, projectRoot, transpileLint, tests, buildDirectory: projectTypeBuildDirectory, dialect: chosenDialect}
       );
       assert.calledWith(npmConfig.default, {projectRoot, projectType, registries});
       assert.calledWith(

--- a/src/scaffolder-test.js
+++ b/src/scaffolder-test.js
@@ -78,7 +78,7 @@ suite('javascript project scaffolder', () => {
   const commitConventionResults = any.simpleObject();
   const applicationTypes = any.simpleObject();
   const packageTypes = any.simpleObject();
-  const transpileLint = any.boolean();
+  const configureLinting = any.boolean();
   const projectTypeBuildDirectory = any.string();
   const packageProperties = any.simpleObject();
   const projectTypeTags = any.listOf(any.word);
@@ -128,7 +128,7 @@ suite('javascript project scaffolder', () => {
     [commonQuestionNames.CI_SERVICE]: chosenCiService,
     [questionNames.HOST]: chosenHost,
     [questionNames.NODE_VERSION_CATEGORY]: versionCategory,
-    [questionNames.TRANSPILE_LINT]: transpileLint,
+    [questionNames.CONFIGURE_LINTING]: configureLinting,
     [questionNames.PACKAGE_MANAGER]: packageManager,
     [questionNames.DIALECT]: chosenDialect
   };
@@ -159,7 +159,6 @@ suite('javascript project scaffolder', () => {
       .withArgs({
         projectType,
         projectRoot,
-        transpileLint,
         projectName,
         packageName,
         packageManager,
@@ -204,7 +203,7 @@ suite('javascript project scaffolder', () => {
         dialect: chosenDialect,
         registries,
         vcs: vcsDetails,
-        transpileLint,
+        configureLinting,
         buildDirectory: projectTypeBuildDirectory,
         eslint: {
           ...testingEslintOtherDetails,

--- a/src/scaffolder-test.js
+++ b/src/scaffolder-test.js
@@ -201,6 +201,7 @@ suite('javascript project scaffolder', () => {
         projectRoot,
         projectType,
         packageManager,
+        dialect: chosenDialect,
         registries,
         vcs: vcsDetails,
         transpileLint,

--- a/src/scaffolder-test.js
+++ b/src/scaffolder-test.js
@@ -211,14 +211,7 @@ suite('javascript project scaffolder', () => {
       })
       .resolves(lintingResults);
     dialects.default
-      .withArgs({
-        projectRoot,
-        configs,
-        transpileLint,
-        tests,
-        buildDirectory: projectTypeBuildDirectory,
-        dialect: chosenDialect
-      })
+      .withArgs({projectRoot, configs, tests, buildDirectory: projectTypeBuildDirectory, dialect: chosenDialect})
       .resolves(babelResults);
     npmConfig.default.resolves(npmResults);
     commitConvention.default
@@ -263,7 +256,7 @@ suite('javascript project scaffolder', () => {
 
       assert.calledWith(
         dialects.default,
-        {configs, projectRoot, transpileLint, tests, buildDirectory: projectTypeBuildDirectory, dialect: chosenDialect}
+        {configs, projectRoot, tests, buildDirectory: projectTypeBuildDirectory, dialect: chosenDialect}
       );
       assert.calledWith(npmConfig.default, {projectRoot, projectType, registries});
       assert.calledWith(

--- a/src/scaffolder.js
+++ b/src/scaffolder.js
@@ -95,6 +95,7 @@ export async function scaffold(options) {
         projectRoot,
         projectType,
         packageManager,
+        dialect,
         registries,
         vcs,
         transpileLint,

--- a/src/scaffolder.js
+++ b/src/scaffolder.js
@@ -104,14 +104,7 @@ export async function scaffold(options) {
         )
       }),
       scaffoldChoice(ciServices, ci, {projectRoot, vcs, visibility, projectType, projectName, nodeVersion, tests}),
-      scaffoldDialect({
-        dialect,
-        configs,
-        projectRoot,
-        transpileLint,
-        tests,
-        buildDirectory: projectTypeResults.buildDirectory
-      }),
+      scaffoldDialect({dialect, configs, projectRoot, tests, buildDirectory: projectTypeResults.buildDirectory}),
       scaffoldCommitConvention({projectRoot, configs, pathWithinParent, packageManager})
     ])),
     projectTypeResults,

--- a/src/scaffolder.js
+++ b/src/scaffolder.js
@@ -56,7 +56,7 @@ export async function scaffold(options) {
     [questionNames.TRANSPILE_LINT]: transpileLint,
     [questionNames.PACKAGE_MANAGER]: packageManager,
     [questionNames.DIALECT]: dialect
-  } = await prompt(overrides, ciServices, hosts, visibility, vcs, decisions, pathWithinParent);
+  } = await prompt(overrides, ciServices, hosts, visibility, vcs, decisions, configs, pathWithinParent);
 
   info('Writing project files', {level: 'secondary'});
 

--- a/src/scaffolder.js
+++ b/src/scaffolder.js
@@ -53,7 +53,7 @@ export async function scaffold(options) {
     [questionNames.AUTHOR_NAME]: authorName,
     [questionNames.AUTHOR_EMAIL]: authorEmail,
     [questionNames.AUTHOR_URL]: authorUrl,
-    [questionNames.TRANSPILE_LINT]: transpileLint,
+    [questionNames.CONFIGURE_LINTING]: configureLinting,
     [questionNames.PACKAGE_MANAGER]: packageManager,
     [questionNames.DIALECT]: dialect
   } = await prompt(overrides, ciServices, hosts, visibility, vcs, decisions, configs, pathWithinParent);
@@ -68,7 +68,6 @@ export async function scaffold(options) {
     projectName,
     packageName,
     packageManager,
-    transpileLint,
     visibility,
     applicationTypes,
     packageTypes,
@@ -98,7 +97,7 @@ export async function scaffold(options) {
         dialect,
         registries,
         vcs,
-        transpileLint,
+        configureLinting,
         buildDirectory: projectTypeResults.buildDirectory,
         eslint: deepmerge(
           testingResults.eslint,

--- a/src/scaffolder.js
+++ b/src/scaffolder.js
@@ -54,7 +54,8 @@ export async function scaffold(options) {
     [questionNames.AUTHOR_EMAIL]: authorEmail,
     [questionNames.AUTHOR_URL]: authorUrl,
     [questionNames.TRANSPILE_LINT]: transpileLint,
-    [questionNames.PACKAGE_MANAGER]: packageManager
+    [questionNames.PACKAGE_MANAGER]: packageManager,
+    [questionNames.DIALECT]: dialect
   } = await prompt(overrides, ciServices, hosts, visibility, vcs, decisions, pathWithinParent);
 
   info('Writing project files', {level: 'secondary'});
@@ -103,7 +104,14 @@ export async function scaffold(options) {
         )
       }),
       scaffoldChoice(ciServices, ci, {projectRoot, vcs, visibility, projectType, projectName, nodeVersion, tests}),
-      scaffoldDialect({configs, projectRoot, transpileLint, tests, buildDirectory: projectTypeResults.buildDirectory}),
+      scaffoldDialect({
+        dialect,
+        configs,
+        projectRoot,
+        transpileLint,
+        tests,
+        buildDirectory: projectTypeResults.buildDirectory
+      }),
       scaffoldCommitConvention({projectRoot, configs, pathWithinParent, packageManager})
     ])),
     projectTypeResults,

--- a/src/scaffolder.js
+++ b/src/scaffolder.js
@@ -75,7 +75,8 @@ export async function scaffold(options) {
     scope,
     tests,
     vcs,
-    decisions
+    decisions,
+    dialect
   });
   const testingResults = await scaffoldTesting({projectRoot, tests, visibility, vcs, unitTestFrameworks, decisions});
   const [nodeVersion, npmResults] = await Promise.all([

--- a/test/integration/features/application.feature
+++ b/test/integration/features/application.feature
@@ -2,6 +2,7 @@ Feature: Application Project Type
 
   Scenario: Minimal Options for an Application
     Given the project will be an "Application"
+    And the project will use the "babel" dialect
     And the project will be versioned on GitHub
     And the default answers are chosen
     And the project will have "Public" visibility

--- a/test/integration/features/cli.feature
+++ b/test/integration/features/cli.feature
@@ -2,6 +2,7 @@ Feature: CLI Project Type
 
   Scenario: Minimal Options for a CLI
     Given the project will be a "CLI"
+    And the project will use the "babel" dialect
     And the project will be versioned on GitHub
     And the default answers are chosen
     And the project will have "Public" visibility

--- a/test/integration/features/dialect.feature
+++ b/test/integration/features/dialect.feature
@@ -10,7 +10,6 @@ Feature: Dialects
     When the project is scaffolded
     Then the "babel" dialect is configured
 
-  @wip
   Scenario: Babel without a preset provided
     Given the project will be an "any"
     And the project will use the "babel" dialect

--- a/test/integration/features/dialect.feature
+++ b/test/integration/features/dialect.feature
@@ -2,6 +2,7 @@ Feature: Dialects
 
   Scenario: Babel
     Given the project will be an "any"
+    And the project will use the "babel" dialect
     And the npm cli is logged in
     And the project will not be tested
     And nvm is properly configured
@@ -12,6 +13,7 @@ Feature: Dialects
   @wip
   Scenario: Babel without a preset provided
     Given the project will be an "any"
+    And the project will use the "babel" dialect
     And the npm cli is logged in
     And the project will not be tested
     And nvm is properly configured
@@ -19,26 +21,34 @@ Feature: Dialects
     When the project is scaffolded
     Then an error is reported about the missing babel preset
 
-  @wip
   Scenario: Common JS
     Given the project will be an "any"
+    And the project will use the "common-js" dialect
     And the npm cli is logged in
     And the project will not be tested
     And nvm is properly configured
+    And a babel preset is provided
     When the project is scaffolded
+    Then the "common-js" dialect is configured
 
   @wip
   Scenario: EcmaScript Module
     Given the project will be an "any"
+    And the project will use the "esm" dialect
     And the npm cli is logged in
     And the project will not be tested
     And nvm is properly configured
+    And a babel preset is provided
     When the project is scaffolded
+    Then the "esm" dialect is configured
 
   @wip
   Scenario: TypeScript
     Given the project will be an "any"
+    And the project will use the "typescript" dialect
     And the npm cli is logged in
     And the project will not be tested
     And nvm is properly configured
+    And a babel preset is provided
     When the project is scaffolded
+    Then the "typescript" dialect is configured

--- a/test/integration/features/eslint.feature
+++ b/test/integration/features/eslint.feature
@@ -3,6 +3,7 @@ Feature: ESLint
   Scenario: Base Config only
     Given the project will be an "any"
     And the project will use the "babel" dialect
+    And a babel preset is provided
     And the npm cli is logged in
     And the project will not be tested
     And nvm is properly configured
@@ -12,6 +13,7 @@ Feature: ESLint
   Scenario: Base Config with Additional Config
     Given the project will be an "any"
     And the project will use the "babel" dialect
+    And a babel preset is provided
     And the npm cli is logged in
     And the project will not be tested
     And nvm is properly configured
@@ -23,6 +25,7 @@ Feature: ESLint
   Scenario: Base Config with Override Config
     Given the project will be an "Application"
     And the project will use the "babel" dialect
+    And a babel preset is provided
     And the npm cli is logged in
     And the project will not be tested
     And nvm is properly configured

--- a/test/integration/features/eslint.feature
+++ b/test/integration/features/eslint.feature
@@ -2,6 +2,7 @@ Feature: ESLint
 
   Scenario: Base Config only
     Given the project will be an "any"
+    And the project will use the "babel" dialect
     And the npm cli is logged in
     And the project will not be tested
     And nvm is properly configured
@@ -10,6 +11,7 @@ Feature: ESLint
 
   Scenario: Base Config with Additional Config
     Given the project will be an "any"
+    And the project will use the "babel" dialect
     And the npm cli is logged in
     And the project will not be tested
     And nvm is properly configured
@@ -20,6 +22,7 @@ Feature: ESLint
 
   Scenario: Base Config with Override Config
     Given the project will be an "Application"
+    And the project will use the "babel" dialect
     And the npm cli is logged in
     And the project will not be tested
     And nvm is properly configured

--- a/test/integration/features/monorepo.feature
+++ b/test/integration/features/monorepo.feature
@@ -2,6 +2,7 @@ Feature: Monorepo
 
   Scenario: Add package to existing monorepo
     Given the project will be a "Package"
+    And the project will use the "babel" dialect
     And the package will be added to an existing monorepo
     And the project will be versioned on GitHub
     And the default answers are chosen

--- a/test/integration/features/package-manager.feature
+++ b/test/integration/features/package-manager.feature
@@ -2,6 +2,7 @@ Feature: Package manager
 
   Scenario: npm
     Given the project will be an "any"
+    And the project will use the "babel" dialect
     And the npm cli is logged in
     And nvm is properly configured
     And the project will not be tested
@@ -12,6 +13,7 @@ Feature: Package manager
 
   Scenario: yarn
     Given the project will be an "any"
+    And the project will use the "babel" dialect
     And the yarn cli is logged in
     And nvm is properly configured
     And the project will not be tested
@@ -22,6 +24,7 @@ Feature: Package manager
 
   Scenario: yarn package
     Given the project will be an "Package"
+    And the project will use the "babel" dialect
     And the yarn cli is logged in
     And nvm is properly configured
     And the project will not be tested

--- a/test/integration/features/package-manager.feature
+++ b/test/integration/features/package-manager.feature
@@ -3,6 +3,7 @@ Feature: Package manager
   Scenario: npm
     Given the project will be an "any"
     And the project will use the "babel" dialect
+    And a babel preset is provided
     And the npm cli is logged in
     And nvm is properly configured
     And the project will not be tested
@@ -14,6 +15,7 @@ Feature: Package manager
   Scenario: yarn
     Given the project will be an "any"
     And the project will use the "babel" dialect
+    And a babel preset is provided
     And the yarn cli is logged in
     And nvm is properly configured
     And the project will not be tested
@@ -25,6 +27,7 @@ Feature: Package manager
   Scenario: yarn package
     Given the project will be an "Package"
     And the project will use the "babel" dialect
+    And a babel preset is provided
     And the yarn cli is logged in
     And nvm is properly configured
     And the project will not be tested

--- a/test/integration/features/package.feature
+++ b/test/integration/features/package.feature
@@ -33,7 +33,7 @@ Feature: Package Project Type
 
   Scenario: Without testing, transpilation, or linting
     Given the project will be a "Package"
-    And the project will use the "babel" dialect
+    And the project will use the "common-js" dialect
     And the project will be versioned on GitHub
     And the npm cli is logged in
     And nvm is properly configured

--- a/test/integration/features/package.feature
+++ b/test/integration/features/package.feature
@@ -2,6 +2,7 @@ Feature: Package Project Type
 
   Scenario: Minimal Options w/o Versioning
     Given the project will be a "Package"
+    And the project will use the "babel" dialect
     And the project will not be versioned
     And the project will have "Private" visibility
     And the default answers are chosen
@@ -17,6 +18,7 @@ Feature: Package Project Type
 
   Scenario: Minimal Options w/ Versioning
     Given the project will be a "Package"
+    And the project will use the "babel" dialect
     And the project will be versioned on GitHub
     And the project will have "Public" visibility
     And the default answers are chosen
@@ -31,6 +33,7 @@ Feature: Package Project Type
 
   Scenario: Without testing, transpilation, or linting
     Given the project will be a "Package"
+    And the project will use the "babel" dialect
     And the project will be versioned on GitHub
     And the npm cli is logged in
     And nvm is properly configured

--- a/test/integration/features/registries.feature
+++ b/test/integration/features/registries.feature
@@ -2,6 +2,7 @@ Feature: Registries
 
   Scenario: registries defined for scopes
     Given the project will be an "any"
+    And the project will use the "babel" dialect
     And the npm cli is logged in
     And the project will not be tested
     And nvm is properly configured

--- a/test/integration/features/registries.feature
+++ b/test/integration/features/registries.feature
@@ -3,6 +3,7 @@ Feature: Registries
   Scenario: registries defined for scopes
     Given the project will be an "any"
     And the project will use the "babel" dialect
+    And a babel preset is provided
     And the npm cli is logged in
     And the project will not be tested
     And nvm is properly configured

--- a/test/integration/features/step_definitions/common-steps.js
+++ b/test/integration/features/step_definitions/common-steps.js
@@ -131,7 +131,8 @@ When(/^the project is scaffolded$/, async function () {
         [questionNames.SHOULD_BE_SCOPED]: shouldBeScopedAnswer,
         ...shouldBeScopedAnswer && {[questionNames.SCOPE]: this.npmAccount}
       },
-      ...this.packageManager && {[questionNames.PACKAGE_MANAGER]: this.packageManager}
+      ...this.packageManager && {[questionNames.PACKAGE_MANAGER]: this.packageManager},
+      [questionNames.DIALECT]: this.dialect
     },
     unitTestFrameworks: {
       foo: {scaffolder: ({foo}) => ({foo})},

--- a/test/integration/features/step_definitions/common-steps.js
+++ b/test/integration/features/step_definitions/common-steps.js
@@ -99,54 +99,58 @@ When(/^the project is scaffolded$/, async function () {
   const shouldBeScopedAnswer = true;
   this.projectName = `${any.word()}-${any.word()}`;
 
-  this.scaffoldResult = await scaffold({
-    projectRoot: process.cwd(),
-    projectName: this.projectName,
-    visibility: this.visibility,
-    license: any.string(),
-    vcs: this.vcs,
-    configs: {
-      eslint: {scope: this.eslintScope},
-      babelPreset: this.babelPreset,
-      commitlint: {name: any.word(), packageName: any.word()}
-    },
-    ciServices: {[any.word()]: {scaffolder: foo => ({foo}), public: true}},
-    applicationTypes: {
-      foo: {scaffolder: foo => ({foo, eslintConfigs: this.fooApplicationEslintConfigs})}
-    },
-    decisions: {
-      [questionNames.NODE_VERSION_CATEGORY]: 'LTS',
-      [questionNames.PROJECT_TYPE]: this.projectType,
-      [questionNames.AUTHOR_NAME]: any.word(),
-      [questionNames.AUTHOR_EMAIL]: any.email(),
-      [questionNames.AUTHOR_URL]: any.url(),
-      [commonQuestionNames.UNIT_TESTS]: this.unitTestAnswer,
-      ...this.unitTestAnswer && {[jsCoreQuestionNames.UNIT_TEST_FRAMEWORK]: this.unitTestFrameworkAnswer},
-      [commonQuestionNames.INTEGRATION_TESTS]: this.integrationTestAnswer,
-      ...null !== this.ciAnswer && {[commonQuestionNames.CI_SERVICE]: this.ciAnswer || 'Other'},
-      [questionNames.TRANSPILE_LINT]: this.transpileAndLint,
-      [questionNames.PROJECT_TYPE_CHOICE]: this.projectTypeChoiceAnswer || 'Other',
-      [questionNames.HOST]: 'Other',
-      ...['Package', 'CLI'].includes(this.projectType) && {
-        [questionNames.SHOULD_BE_SCOPED]: shouldBeScopedAnswer,
-        ...shouldBeScopedAnswer && {[questionNames.SCOPE]: this.npmAccount}
+  try {
+    this.scaffoldResult = await scaffold({
+      projectRoot: process.cwd(),
+      projectName: this.projectName,
+      visibility: this.visibility,
+      license: any.string(),
+      vcs: this.vcs,
+      configs: {
+        eslint: {scope: this.eslintScope},
+        babelPreset: this.babelPreset,
+        commitlint: {name: any.word(), packageName: any.word()}
       },
-      ...this.packageManager && {[questionNames.PACKAGE_MANAGER]: this.packageManager},
-      [questionNames.DIALECT]: this.dialect
-    },
-    unitTestFrameworks: {
-      foo: {scaffolder: ({foo}) => ({foo})},
-      bar: {
-        scaffolder: ({bar}) => ({
-          eslint: {configs: this.barUnitTestFrameworkEslintConfigs},
-          eslintConfigs: this.barUnitTestFrameworkEslintConfigs,
-          bar
-        })
-      }
-    },
-    pathWithinParent: this.pathWithinParent,
-    ...this.registries && {registries: this.registries}
-  });
+      ciServices: {[any.word()]: {scaffolder: foo => ({foo}), public: true}},
+      applicationTypes: {
+        foo: {scaffolder: foo => ({foo, eslintConfigs: this.fooApplicationEslintConfigs})}
+      },
+      decisions: {
+        [questionNames.NODE_VERSION_CATEGORY]: 'LTS',
+        [questionNames.PROJECT_TYPE]: this.projectType,
+        [questionNames.AUTHOR_NAME]: any.word(),
+        [questionNames.AUTHOR_EMAIL]: any.email(),
+        [questionNames.AUTHOR_URL]: any.url(),
+        [commonQuestionNames.UNIT_TESTS]: this.unitTestAnswer,
+        ...this.unitTestAnswer && {[jsCoreQuestionNames.UNIT_TEST_FRAMEWORK]: this.unitTestFrameworkAnswer},
+        [commonQuestionNames.INTEGRATION_TESTS]: this.integrationTestAnswer,
+        ...null !== this.ciAnswer && {[commonQuestionNames.CI_SERVICE]: this.ciAnswer || 'Other'},
+        [questionNames.TRANSPILE_LINT]: this.transpileAndLint,
+        [questionNames.PROJECT_TYPE_CHOICE]: this.projectTypeChoiceAnswer || 'Other',
+        [questionNames.HOST]: 'Other',
+        ...['Package', 'CLI'].includes(this.projectType) && {
+          [questionNames.SHOULD_BE_SCOPED]: shouldBeScopedAnswer,
+          ...shouldBeScopedAnswer && {[questionNames.SCOPE]: this.npmAccount}
+        },
+        ...this.packageManager && {[questionNames.PACKAGE_MANAGER]: this.packageManager},
+        [questionNames.DIALECT]: this.dialect
+      },
+      unitTestFrameworks: {
+        foo: {scaffolder: ({foo}) => ({foo})},
+        bar: {
+          scaffolder: ({bar}) => ({
+            eslint: {configs: this.barUnitTestFrameworkEslintConfigs},
+            eslintConfigs: this.barUnitTestFrameworkEslintConfigs,
+            bar
+          })
+        }
+      },
+      pathWithinParent: this.pathWithinParent,
+      ...this.registries && {registries: this.registries}
+    });
+  } catch (e) {
+    this.resultError = e;
+  }
 });
 
 Then('the expected files for a(n) {string} are generated', async function (projectType) {

--- a/test/integration/features/step_definitions/common-steps.js
+++ b/test/integration/features/step_definitions/common-steps.js
@@ -125,7 +125,7 @@ When(/^the project is scaffolded$/, async function () {
         ...this.unitTestAnswer && {[jsCoreQuestionNames.UNIT_TEST_FRAMEWORK]: this.unitTestFrameworkAnswer},
         [commonQuestionNames.INTEGRATION_TESTS]: this.integrationTestAnswer,
         ...null !== this.ciAnswer && {[commonQuestionNames.CI_SERVICE]: this.ciAnswer || 'Other'},
-        [questionNames.TRANSPILE_LINT]: this.transpileAndLint,
+        [questionNames.CONFIGURE_LINTING]: this.transpileAndLint,
         [questionNames.PROJECT_TYPE_CHOICE]: this.projectTypeChoiceAnswer || 'Other',
         [questionNames.HOST]: 'Other',
         ...['Package', 'CLI'].includes(this.projectType) && {

--- a/test/integration/features/step_definitions/dialect-steps.js
+++ b/test/integration/features/step_definitions/dialect-steps.js
@@ -34,6 +34,5 @@ Then('the {string} dialect is configured', async function (dialect) {
 });
 
 Then('an error is reported about the missing babel preset', async function () {
-  // Write code here that turns the phrase above into concrete actions
-  return 'pending';
+  assert.equal(this.resultError.message, 'No babel preset provided. Cannot configure babel transpilation');
 });

--- a/test/integration/features/step_definitions/dialect-steps.js
+++ b/test/integration/features/step_definitions/dialect-steps.js
@@ -18,7 +18,9 @@ Given('no babel preset is provided', async function () {
 });
 
 Then('the {string} dialect is configured', async function (dialect) {
-  if ('babel' === dialect) {
+  const {dialects} = require('@form8ion/javascript-core');
+
+  if (dialects.BABEL === dialect) {
     const {presets, ignore} = JSON.parse(await fs.readFile(`${process.cwd()}/.babelrc`, 'utf-8'));
 
     assert.deepEqual(presets, [this.babelPreset.name]);
@@ -26,7 +28,7 @@ Then('the {string} dialect is configured', async function (dialect) {
     assertDevDependencyIsInstalled(this.execa, this.babelPreset.packageName);
   }
 
-  if ('common-js' === dialect) {
+  if (dialects.COMMON_JS === dialect) {
     assert.isFalse(await fileExists(`${process.cwd()}/.babelrc`));
   }
 });

--- a/test/integration/features/step_definitions/dialect-steps.js
+++ b/test/integration/features/step_definitions/dialect-steps.js
@@ -1,8 +1,13 @@
 import {promises as fs} from 'fs';
+import {fileExists} from '@form8ion/core';
 import {Given, Then} from '@cucumber/cucumber';
 import {assert} from 'chai';
 import any from '@travi/any';
 import {assertDevDependencyIsInstalled} from './common-steps';
+
+Given('the project will use the {string} dialect', async function (dialect) {
+  this.dialect = dialect;
+});
 
 Given('a babel preset is provided', async function () {
   this.babelPreset = {name: any.word(), packageName: any.word()};
@@ -19,6 +24,10 @@ Then('the {string} dialect is configured', async function (dialect) {
     assert.deepEqual(presets, [this.babelPreset.name]);
     assert.deepEqual(ignore, [`./${this.buildDirectory}/`]);
     assertDevDependencyIsInstalled(this.execa, this.babelPreset.packageName);
+  }
+
+  if ('common-js' === dialect) {
+    assert.isFalse(await fileExists(`${process.cwd()}/.babelrc`));
   }
 });
 

--- a/test/integration/features/step_definitions/eslint-steps.js
+++ b/test/integration/features/step_definitions/eslint-steps.js
@@ -41,7 +41,7 @@ Given('the chosen application plugin defines override ESLint configs', async fun
 });
 
 Then('the base ESLint config is extended', async function () {
-  const config = load(await fs.readFile(`${process.cwd()}/.eslintrc.yml`));
+  const config = load(await fs.readFile(`${process.cwd()}/.eslintrc.yml`, 'utf-8'));
 
   if ('bar' === this.unitTestFrameworkAnswer) {
     assert.equal(config.extends[0], this.eslintScope);
@@ -51,7 +51,7 @@ Then('the base ESLint config is extended', async function () {
 });
 
 Then('the additional ESLint configs are extended', async function () {
-  const config = load(await fs.readFile(`${process.cwd()}/.eslintrc.yml`));
+  const config = load(await fs.readFile(`${process.cwd()}/.eslintrc.yml`, 'utf-8'));
 
   assert.deepEqual(
     config.extends,


### PR DESCRIPTION
allowed choosing between common-js and modern-js transpiled with babel. this improves the decision that has been enabled for some time but always felt hacky and disorganized. this approach seems far more explicit and for the real reasons that exist for this choice. this also enables finally making progress toward supporting esm and typescript as well, although support for those will be worked on as follow ups to this implementation.